### PR TITLE
Add HO-DET-001 Splunk synthetic source

### DIFF
--- a/detections/successor/ho-det-001/splunk.spl
+++ b/detections/successor/ho-det-001/splunk.spl
@@ -1,0 +1,14 @@
+# HO-DET-001 - Suspicious PowerShell EncodedCommand Execution
+# Scope: Splunk-primary synthetic source for controlled validation only.
+# This artifact does not claim deployment, live firing, runtime status, or public approval.
+
+index=windows (EventCode=1 OR EventID=1)
+(
+  Image="*\\powershell.exe" OR Image="*\\pwsh.exe"
+  OR OriginalFileName="*PowerShell*" OR OriginalFileName="*pwsh*"
+)
+| eval ho_command_line=lower(coalesce(CommandLine, ProcessCommandLine, command_line, ""))
+| where match(ho_command_line, "(^|\\s)(-|/)(enc|encodedcommand)(:|\\s|$)")
+    OR like(ho_command_line, "%frombase64string(%")
+| table _time, host, Computer, User, Image, OriginalFileName, CommandLine, ParentImage
+| sort -_time

--- a/detections/successor/ho-det-001/splunk.spl
+++ b/detections/successor/ho-det-001/splunk.spl
@@ -1,7 +1,3 @@
-# HO-DET-001 - Suspicious PowerShell EncodedCommand Execution
-# Scope: Splunk-primary synthetic source for controlled validation only.
-# This artifact does not claim deployment, live firing, runtime status, or public approval.
-
 index=windows (EventCode=1 OR EventID=1)
 (
   Image="*\\powershell.exe" OR Image="*\\pwsh.exe"


### PR DESCRIPTION
This PR adds the Splunk SPL source artifact for HO-DET-001.

Scope:
- Adds detections/successor/ho-det-001/splunk.spl.
- Source artifact only.
- No proof record update.
- No website update.
- No runtime, signal, evidence, or public-safe promotion.

Claim boundaries:
- Supports: HO-DET-001 has a Splunk SPL source artifact.
- Does not claim runtime-active status.
- Does not claim signal-observed status.
- Does not claim evidence-linked status.
- Does not claim public-safe status.
- Does not claim production-ready status.
- Does not claim live Splunk fired.
- Does not claim Cribl routing.
- Does not claim Wazuh live collection.

Validation:
- Paired validation work is in the validation PR.
- No runtime or signal evidence is introduced by this PR.