### PR TITLE
[DETECTIONS] Add AWS-DET-001 fixture source

### DIFF
--- a/detections/cloud/aws/aws-det-001/README.md
+++ b/detections/cloud/aws/aws-det-001/README.md
@@ -1,0 +1,26 @@
+# AWS-DET-001
+
+Fixture-only source candidate for denied or unauthorized IAM API activity in CloudTrail-style events.
+
+## Scope
+
+- Detection ID: `AWS-DET-001`
+- Source class: CloudTrail-style JSON fixtures
+- Current ceiling: `SOURCE_EXISTS`
+- Public-safe status: `NOT_PUBLIC_SAFE`
+
+This source does not use AWS credentials, live AWS APIs, production telemetry, or CloudTrail live evidence.
+
+## Allowed Claim
+
+`AWS-DET-001 source exists as a fixture-only CloudTrail-style detection candidate.`
+
+## Blocked Claims
+
+- AWS-live proof
+- AWS CloudTrail live proof
+- Cloud runtime-active proof
+- Production proof
+- Public-safe runtime proof
+- Signal-observed public proof
+

--- a/detections/cloud/aws/aws-det-001/cloudtrail.jsonpath
+++ b/detections/cloud/aws/aws-det-001/cloudtrail.jsonpath
@@ -1,0 +1,1 @@
+$.Records[?(@.eventSource=="iam.amazonaws.com" && (@.errorCode =~ /AccessDenied|UnauthorizedOperation|Client\.UnauthorizedOperation/ || @.errorMessage =~ /not authorized|denied/i))]

--- a/detections/cloud/aws/aws-det-001/rule.yml
+++ b/detections/cloud/aws/aws-det-001/rule.yml
@@ -1,0 +1,76 @@
+title: Denied IAM API Activity From CloudTrail-Style Events
+detection_id: AWS-DET-001
+status: SOURCE_EXISTS
+proof_level: "1 SOURCE_EXISTS"
+trust_class: SOURCE_EXISTS
+public_safe_status: NOT_PUBLIC_SAFE
+approval_status: NOT_APPROVED
+runtime_active: "NO"
+validation_status: NOT_YET
+signal_observed: "NO"
+evidence_linked: "NO"
+description: >
+  Fixture-only detection candidate for denied or unauthorized IAM API activity
+  represented in CloudTrail-style JSON events. This source establishes file
+  existence only until fixture validation is run and recorded.
+author: HawkinsOperations
+date: 2026-05-01
+references:
+  - https://attack.mitre.org/techniques/T1098/
+mitre_attack:
+  mapping_status: CANDIDATE
+  tactic_ids:
+    - TA0003
+  tactic_names:
+    - Persistence
+  technique_ids:
+    - T1098
+  technique_names:
+    - Account Manipulation
+data_source:
+  product: aws
+  category: cloudtrail_fixture
+  expected_event_source: iam.amazonaws.com
+backend_target: cloudtrail_json_fixture
+source_assumptions:
+  - Event source is available as eventSource.
+  - Event name is available as eventName.
+  - Error code or error message is available when the API call is denied.
+  - Matching is intended for fixture validation only.
+detection:
+  selection_source:
+    eventSource:
+      - iam.amazonaws.com
+  selection_error:
+    errorCode|contains:
+      - AccessDenied
+      - UnauthorizedOperation
+      - Client.UnauthorizedOperation
+    errorMessage|contains:
+      - not authorized
+      - denied
+  condition: selection_source and selection_error
+falsepositives:
+  - Expected failed IAM administration attempts in controlled tests.
+  - Permission boundary testing.
+  - Misconfigured automation using denied IAM APIs.
+level: medium
+allowed_claim: AWS-DET-001 source exists as a fixture-only CloudTrail-style detection candidate.
+blocked_claims:
+  - AWS-live proof
+  - AWS CloudTrail live proof
+  - cloud runtime-active proof
+  - production proof
+  - public-safe runtime proof
+  - signal-observed public proof
+promotion_boundaries:
+  source_exists_supports:
+    - The AWS-DET-001 source artifact exists at this repository path.
+  source_exists_does_not_support:
+    - live AWS collection
+    - CloudTrail live proof
+    - runtime-active cloud status
+    - signal-observed status
+    - production status
+    - public-safe status
+


### PR DESCRIPTION
## Summary

Adds AWS-DET-001 as a fixture-only CloudTrail-style detection source for denied or unauthorized IAM API activity.

## Files changed

- detections/cloud/aws/aws-det-001/README.md
- detections/cloud/aws/aws-det-001/rule.yml
- detections/cloud/aws/aws-det-001/cloudtrail.jsonpath

## Validation results

Static claim-boundary/private-term scans passed locally. git diff --check passed with line-ending warnings only.

## Current claim ceiling

SOURCE_EXISTS in the detections source repo. Validation proof is handled in the validation/proof PRs and remains fixture-only.

## Blocked claims preserved

No AWS-live, AWS CloudTrail live, cloud runtime-active, production, public-safe runtime proof, signal-observed public proof, autonomous SOC, fleet-wide, AI-approved disposition, or analyst-approved disposition claim is made.

## Private evidence not included

No private ZIPs, raw evidence, local paths, hostnames, LAN IPs, usernames, VM IDs, MAC addresses, raw model output, private evidence filenames, internal service names, device paths, SSH details, Proxmox details, or GPU host labels are included.

## Next gate

Review and merge before the validation PR can run against the default detections branch without a cross-repo dependency.