### PR TITLE
fix(detections): align source metadata with validated synthetic scope

### DIFF
--- a/detections/cloud/aws/aws-det-001/README.md
+++ b/detections/cloud/aws/aws-det-001/README.md
@@ -6,14 +6,14 @@ Fixture-only source candidate for denied or unauthorized IAM API activity in Clo
 
 - Detection ID: `AWS-DET-001`
 - Source class: CloudTrail-style JSON fixtures
-- Current ceiling: `SOURCE_EXISTS`
+- Current ceiling: `TEST_VALIDATED_SYNTHETIC_SCOPE`
 - Public-safe status: `NOT_PUBLIC_SAFE`
 
 This source does not use AWS credentials, live AWS APIs, production telemetry, or CloudTrail live evidence.
 
 ## Allowed Claim
 
-`AWS-DET-001 source exists as a fixture-only CloudTrail-style detection candidate.`
+`AWS-DET-001 passed fixture-only validation against controlled CloudTrail-style IAM denial fixtures.`
 
 ## Blocked Claims
 

--- a/detections/cloud/aws/aws-det-001/rule.yml
+++ b/detections/cloud/aws/aws-det-001/rule.yml
@@ -1,18 +1,19 @@
 title: Denied IAM API Activity From CloudTrail-Style Events
 detection_id: AWS-DET-001
-status: SOURCE_EXISTS
-proof_level: "1 SOURCE_EXISTS"
-trust_class: SOURCE_EXISTS
+status: TEST_VALIDATED_SYNTHETIC_SCOPE
+proof_level: TEST_VALIDATED_SYNTHETIC_SCOPE
+trust_class: TEST_VALIDATED_SYNTHETIC_SCOPE
 public_safe_status: NOT_PUBLIC_SAFE
 approval_status: NOT_APPROVED
 runtime_active: "NO"
-validation_status: NOT_YET
+validation_status: TEST_VALIDATED_SYNTHETIC_SCOPE
 signal_observed: "NO"
 evidence_linked: "NO"
 description: >
   Fixture-only detection candidate for denied or unauthorized IAM API activity
-  represented in CloudTrail-style JSON events. This source establishes file
-  existence only until fixture validation is run and recorded.
+  represented in CloudTrail-style JSON events. This source is fixture-validated
+  against controlled CloudTrail-style cases only; it does not establish AWS-live,
+  CloudTrail-live, runtime, signal, production, or public-safe proof.
 author: HawkinsOperations
 date: 2026-05-01
 references:
@@ -55,7 +56,7 @@ falsepositives:
   - Permission boundary testing.
   - Misconfigured automation using denied IAM APIs.
 level: medium
-allowed_claim: AWS-DET-001 source exists as a fixture-only CloudTrail-style detection candidate.
+allowed_claim: AWS-DET-001 passed fixture-only validation against controlled CloudTrail-style IAM denial fixtures.
 blocked_claims:
   - AWS-live proof
   - AWS CloudTrail live proof
@@ -64,9 +65,10 @@ blocked_claims:
   - public-safe runtime proof
   - signal-observed public proof
 promotion_boundaries:
-  source_exists_supports:
+  test_validated_synthetic_scope_supports:
     - The AWS-DET-001 source artifact exists at this repository path.
-  source_exists_does_not_support:
+    - AWS-DET-001 passed fixture-only validation against controlled CloudTrail-style IAM denial fixtures.
+  test_validated_synthetic_scope_does_not_support:
     - live AWS collection
     - CloudTrail live proof
     - runtime-active cloud status

--- a/detections/successor/ho-det-001/rule.yml
+++ b/detections/successor/ho-det-001/rule.yml
@@ -1,18 +1,20 @@
 title: Suspicious PowerShell EncodedCommand Execution
 detection_id: HO-DET-001
-status: SOURCE_EXISTS
-proof_level: "1 SOURCE_EXISTS"
-trust_class: SOURCE_EXISTS
+status: TEST_VALIDATED_SYNTHETIC_SCOPE
+proof_level: TEST_VALIDATED_SYNTHETIC_SCOPE
+trust_class: TEST_VALIDATED_SYNTHETIC_SCOPE
 public_safe_status: NOT_PUBLIC_SAFE
 approval_status: NOT_APPROVED
 runtime_active: "NO"
-validation_status: NOT_YET
+validation_status: TEST_VALIDATED_SYNTHETIC_SCOPE
 signal_observed: "NO"
 evidence_linked: "NO"
 description: >
   Source artifact for a successor-system detection that identifies PowerShell
   or pwsh process execution using encoded command flags or encoded payload
-  patterns. This source record establishes file existence only.
+  patterns. This source record is synthetically validated against controlled
+  process-creation fixtures only; it does not establish runtime, signal, or
+  public-safe proof.
 author: HawkinsOperations
 date: 2026-04-25
 references:
@@ -61,21 +63,19 @@ falsepositives:
   - Legitimate administrative tooling, automation, deployment scripts, or endpoint management workflows can use encoded PowerShell commands.
   - Environment-specific tuning and allowlisting are required before any runtime claim.
 level: medium
-allowed_claim: Detection source exists for HO-DET-001.
+allowed_claim: HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures.
 blocked_claims:
   - This detection is active.
-  - This detection passed validation.
+  - This detection passed runtime validation.
   - This catches attacks.
   - This proves coverage.
   - This is public-safe.
   - The repo proves runtime behavior.
 promotion_boundaries:
-  source_exists_supports:
+  test_validated_synthetic_scope_supports:
     - The HO-DET-001 source artifact exists at this repository path.
-  source_exists_does_not_support:
-    - static validation
-    - test definition
-    - test validation
+    - HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures.
+  test_validated_synthetic_scope_does_not_support:
     - runtime-active status
     - signal-observed status
     - evidence-linked status


### PR DESCRIPTION
## Summary

- Reconciles source metadata only for HO-DET-001 and AWS-DET-001.
- HO-DET-001 remains TEST_VALIDATED_SYNTHETIC_SCOPE.
- AWS-DET-001 remains TEST_VALIDATED_SYNTHETIC_SCOPE / fixture-only.
- runtime-active, signal-observed, public-safe, production, fleet-wide, AWS-live, Cribl-routed, Wazuh-routed, autonomous SOC, AI-approved disposition, and analyst-approved disposition remain blocked.
- .github/CODEOWNERS was intentionally excluded.

## Verification

- git status --short --branch reviewed before staging.
- git diff --check passed in detections.
- HO/AWS validation verifier suite passed from hawkinsoperations-validation with FAILURES=0.