### PR TITLE
docs(detections): align HO-DET-001 blocked claims metadata

### DIFF
--- a/detections/successor/ho-det-001/status.yml
+++ b/detections/successor/ho-det-001/status.yml
@@ -30,6 +30,10 @@ blocked_claims:
   - HO-GPU-01 runtime-active
   - autonomous SOC
   - AI-approved disposition
+  - analyst-approved disposition
+  - enterprise deployed
+  - complete AutoSOC
+  - production AutoSOC triage
 
 allowed_claims:
   - HO-DET-001 source exists.


### PR DESCRIPTION
Summary:
- Aligns HO-DET-001 status metadata with the current blocked-claims inventory.
- Updates metadata only.
- Does not change detection logic or Splunk SPL logic.
- Explicitly excludes .github/CODEOWNERS.

Claim boundary:
- HO-DET-001 remains TEST_VALIDATED_SYNTHETIC_SCOPE.
- This PR does not prove runtime-active, signal-observed, evidence-linked public proof, public-safe status, production-ready status, fleet-wide coverage, Cribl-routed status, Wazuh-routed status, AWS-live status, HO-GPU-01 runtime-active status, autonomous SOC operation, AI-approved disposition, analyst-approved disposition, live Splunk fired as public proof, production AutoSOC triage, enterprise deployed status, or complete AutoSOC status.

Validation:
- git diff --cached --check passed before commit.
- Commit created locally as 951bff32d0a304f43c1a810151f755f8edc775cf.
- Cached diff contained only detections/successor/ho-det-001/status.yml.
- .github/CODEOWNERS remains intentionally excluded.