### PR TITLE
docs(detections): scope CODEOWNERS review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,14 @@
-* @raylee-hawkins
+# CODEOWNERS
+#
+# Purpose: review routing boundaries for detection source files.
+# Status: SOFT_ENFORCEMENT until GitHub branch protection or rulesets require CODEOWNERS review.
+#
+# TODO: Replace placeholder owner with verified org team slugs before enforcing branch rules.
+# Candidate teams:
+# @HawkinsOperations/proof-reviewers
+# @HawkinsOperations/detections-maintainers
+# @HawkinsOperations/validation-maintainers
+# @HawkinsOperations/website-maintainers
+# @HawkinsOperations/org-maintainers
+
+detections/** @raylee-hawkins


### PR DESCRIPTION
Summary:
- Scopes detections CODEOWNERS review routing to detection source paths.
- Labels CODEOWNERS as SOFT_ENFORCEMENT until GitHub branch protection or rulesets require CODEOWNERS review.
- Leaves candidate org team slugs commented until verified.

Claim boundary:
- CODEOWNERS is reviewer routing only unless branch protection or rulesets enforce it.
- This PR does not promote HO-DET-001 beyond TEST_VALIDATED_SYNTHETIC_SCOPE.
- This PR does not prove runtime-active, signal-observed, public-safe status, production-ready status, fleet-wide coverage, or any runtime routing claim.

Validation:
- Claim-boundary scan on .github/CODEOWNERS produced no blocked-term hits.
- Private/public-safety scan on .github/CODEOWNERS produced no hits.
- git diff --check passed.
- Commit contains only .github/CODEOWNERS.