### PR TITLE
feat(detections): tune HO-DET-011 reviewer package

### DIFF
--- a/detections/successor/ho-det-011/README.md
+++ b/detections/successor/ho-det-011/README.md
@@ -24,6 +24,21 @@ Out of scope:
 - Public proof.
 - Completeness claims for service-creation visibility.
 
+## Detection Behavior
+
+HO-DET-011 is intended to raise review interest when service-install telemetry includes a suspicious service binary path, or when process telemetry shows service creation tooling with suspicious service-creation command-line patterns.
+
+The main review pivots are:
+
+- Service image path fields such as `ImagePath`, `ServiceFileName`, `param2`, or normalized backend equivalents.
+- Service names where available.
+- Process image and command-line context where Sysmon Event ID 1 or equivalent process telemetry is available.
+- Parent process context where available.
+
+Suspicious service path indicators include user-writable or commonly abused locations such as AppData, Temp, ProgramData, Public, Downloads, Windows Temp, and PerfLogs. Suspicious wrapper indicators include PowerShell, pwsh, cmd, rundll32, regsvr32, mshta, wscript, cscript, and script-like service targets such as `.ps1`, `.vbs`, `.js`, `.hta`, `.bat`, or `.cmd`.
+
+The detection is not intended to flag every service creation event. Service creation is common during normal administration, installation, management, update, security, backup, driver, monitoring, and remote-support workflows. Reviewer-grade use requires comparing the service path, service name, signer/vendor context, parent process, account, and change window before escalation.
+
 ## Detection Surfaces
 
 - `rule.yml` provides a Sigma-style source record.
@@ -40,13 +55,43 @@ Windows Security Event ID 4697 may be available where audit policy records servi
 
 Sysmon Event ID 1 can provide process context for service creation tooling and parent/command-line review, but this source does not require Sysmon to claim that service-install telemetry exists.
 
+Command-line review depends on process telemetry collection. Windows System 7045 and Windows Security 4697 may provide service image path data without full creator command-line context.
+
 ## False-Positive Boundary
 
 Expected benign sources include software installation, endpoint management, driver installation, patching, backup agents, monitoring agents, and authorized administrator activity. Future validation must separate expected service-install activity from suspicious service image paths or suspicious creation tooling.
 
+Tuning should account for:
+
+- Approved endpoint management and software deployment tools.
+- Signed vendor installers and update services.
+- Driver, print, backup, monitoring, security, and remote-support agents.
+- Known service paths under managed application directories.
+- Administrator activity during approved maintenance windows.
+
+Tuning should not suppress user-writable service paths or interpreter-backed service paths without environment-specific approval and validation evidence.
+
 ## Validation Boundary
 
 Validation is planned, not complete. Future validation should use controlled positive and negative fixtures that distinguish benign service installation from suspicious service image path or tooling patterns.
+
+No HO-DET-011 fixtures were found in this detections repository during this tuning pass. Fixture expansion belongs in a separately scoped `hawkinsoperations-validation` lane unless fixture paths are later added to this repository.
+
+Suggested future fixture coverage:
+
+- Positive service-install fixture using a suspicious user-writable service image path.
+- Positive service-install fixture using `ServiceFileName` instead of `ImagePath`.
+- Positive process-context fixture using service creation tooling and `binPath=`.
+- Negative benign installer/update fixture under a managed application path.
+- Negative benign driver/security/backup/remote-support fixture.
+
+## Supported Claims
+
+This package supports only these source-quality claims:
+
+- HO-DET-011 detection source artifacts exist in this repository.
+- HO-DET-011 includes Sigma-style YAML, Splunk SPL, Wazuh XML, event mapping, status metadata, and tuning notes.
+- HO-DET-011 is prepared for separately scoped synthetic validation.
 
 ## Blocked Claims
 
@@ -56,10 +101,17 @@ This source must not be cited as evidence for:
 - signal-observed
 - public-safe
 - evidence-linked public proof
+- Cribl-routed
 - live Splunk fired
 - Wazuh-routed
+- Security Onion observed
+- Suricata observed
+- Zeek observed
 - production-ready
 - fleet-wide
+- autonomous SOC
+- AI-approved disposition
+- analyst-approved disposition
 - attack coverage
 - service-creation coverage completeness
 - validation passed

--- a/detections/successor/ho-det-011/event-mapping.yml
+++ b/detections/successor/ho-det-011/event-mapping.yml
@@ -111,6 +111,11 @@ splunk_fields:
       - ProcessCommandLine
       - command_line
       - winlog_event_data_CommandLine
+  parent_image:
+    candidates:
+      - ParentImage
+      - parent_process_path
+      - winlog_event_data_ParentImage
 wazuh_fields:
   event_id:
     candidates:
@@ -130,15 +135,50 @@ wazuh_fields:
   command_line:
     candidates:
       - win.eventdata.commandLine
+  parent_image:
+    candidates:
+      - win.eventdata.parentImage
+tuning_fields:
+  required_for_primary_service_path_review:
+    - event_id
+    - service_name
+    - service_image_path
+  useful_for_reviewer_triage:
+    - process_image
+    - command_line
+    - parent_image
+    - account_name
+    - host
+  suspicious_path_indicators:
+    - user-writable paths
+    - temporary paths
+    - public/download/profile paths
+    - interpreter-backed service targets
+    - script-like service targets
+  benign_context_indicators:
+    - approved installer or updater service
+    - driver, print, backup, monitoring, security, or remote-support agent
+    - managed application directory
+    - approved maintenance window
+validation_fixture_boundary:
+  detections_repo_fixtures_found: false
+  validation_repo_fixture_set: REQUIRED_SEPARATE_SCOPE
 blocked_claims:
   - runtime-active
   - signal-observed
   - public-safe
   - evidence-linked public proof
+  - Cribl-routed
   - live Splunk fired
   - Wazuh-routed
+  - Security Onion observed
+  - Suricata observed
+  - Zeek observed
   - production-ready
   - fleet-wide
+  - autonomous SOC
+  - AI-approved disposition
+  - analyst-approved disposition
   - attack coverage
   - service-creation coverage completeness
   - validation passed

--- a/detections/successor/ho-det-011/rule.yml
+++ b/detections/successor/ho-det-011/rule.yml
@@ -59,7 +59,10 @@ data_source:
 backend_target: generic_yaml_source_record
 source_assumptions:
   - Service name and service image path are available for service-install events.
+  - Windows System 7045 service image path data may appear as ImagePath, ServiceFileName, or backend-normalized parameter fields.
+  - Windows Security 4697 service image path data may appear as ServiceFileName or backend-normalized equivalents.
   - Process image and command line may be available through Sysmon Event ID 1 or equivalent process telemetry.
+  - Command-line review is opportunistic; service-install telemetry can exist without creator process command-line context.
   - Matching is intended to be case-insensitive where the backend supports it.
   - Backend-specific deployment, routing, tuning, and validation are not part of this source artifact.
 detection:
@@ -83,6 +86,9 @@ detection:
       - '\ProgramData\'
       - '\Public\'
       - '\Downloads\'
+      - '\Users\Public\'
+      - '\Windows\Temp\'
+      - '\PerfLogs\'
       - 'powershell'
       - 'pwsh'
       - 'cmd.exe'
@@ -91,6 +97,12 @@ detection:
       - 'mshta'
       - 'wscript'
       - 'cscript'
+      - '.ps1'
+      - '.vbs'
+      - '.js'
+      - '.hta'
+      - '.bat'
+      - '.cmd'
   selection_suspicious_service_file_name:
     ServiceFileName|contains:
       - '\AppData\'
@@ -98,6 +110,9 @@ detection:
       - '\ProgramData\'
       - '\Public\'
       - '\Downloads\'
+      - '\Users\Public\'
+      - '\Windows\Temp\'
+      - '\PerfLogs\'
       - 'powershell'
       - 'pwsh'
       - 'cmd.exe'
@@ -106,23 +121,42 @@ detection:
       - 'mshta'
       - 'wscript'
       - 'cscript'
+      - '.ps1'
+      - '.vbs'
+      - '.js'
+      - '.hta'
+      - '.bat'
+      - '.cmd'
   selection_suspicious_command_line:
     CommandLine|contains:
       - ' create '
       - ' New-Service'
       - ' sc.exe create'
+      - ' sc create'
       - ' binPath='
       - ' -EncodedCommand'
       - 'FromBase64String'
   condition: >
-    (selection_system_7045 or selection_security_4697) and
-    (selection_suspicious_image_path or selection_suspicious_service_file_name) or
-    selection_sysmon_tooling and selection_suspicious_command_line
+    ((selection_system_7045 or selection_security_4697) and
+    (selection_suspicious_image_path or selection_suspicious_service_file_name)) or
+    (selection_sysmon_tooling and selection_suspicious_command_line)
 falsepositives:
   - Authorized software installation and upgrade workflows.
   - Endpoint management, monitoring, backup, print, driver, or remote support agents.
   - Administrator-created services during approved maintenance windows.
   - Security tooling that installs or updates service components.
+tuning_guidance:
+  suspicious_path_review:
+    - Prioritize services whose binary path is under user-writable or temporary directories.
+    - Review interpreter-backed service paths and script-like targets before escalation.
+    - Compare ImagePath and ServiceFileName because backends may normalize either field.
+  command_line_review:
+    - Review sc.exe create, sc create, New-Service, binPath=, EncodedCommand, and FromBase64String patterns where process telemetry exists.
+    - Do not require command-line context for Windows System 7045 or Windows Security 4697 service-install events.
+  benign_review_patterns:
+    - Signed vendor installers and approved software deployment tools.
+    - Driver, print, backup, monitoring, security, and remote-support agents.
+    - Known managed application paths and approved maintenance windows.
 level: medium
 allowed_claim: HO-DET-011 source artifacts exist and are prepared for future synthetic validation.
 blocked_claims:
@@ -130,10 +164,17 @@ blocked_claims:
   - signal-observed
   - public-safe
   - evidence-linked public proof
+  - Cribl-routed
   - live Splunk fired
   - Wazuh-routed
+  - Security Onion observed
+  - Suricata observed
+  - Zeek observed
   - production-ready
   - fleet-wide
+  - autonomous SOC
+  - AI-approved disposition
+  - analyst-approved disposition
   - attack coverage
   - service-creation coverage completeness
   - validation passed
@@ -149,3 +190,6 @@ promotion_boundaries:
     - live Splunk firing
     - Wazuh-routed telemetry
     - validation passage
+validation_fixture_boundary:
+  detections_repo_fixtures_found: false
+  validation_repo_fixture_set: REQUIRED_SEPARATE_SCOPE

--- a/detections/successor/ho-det-011/splunk.spl
+++ b/detections/successor/ho-det-011/splunk.spl
@@ -17,6 +17,7 @@ OR
 | eval ho_service_path=lower(coalesce(ImagePath, ServiceFileName, service_file_name, param2, winlog_event_data_ImagePath, winlog_event_data_ServiceFileName, ""))
 | eval ho_process_image=lower(coalesce(Image, process_path, winlog_event_data_Image, ""))
 | eval ho_command_line=lower(coalesce(CommandLine, ProcessCommandLine, command_line, winlog_event_data_CommandLine, ""))
+| eval ho_parent_image=lower(coalesce(ParentImage, parent_process_path, winlog_event_data_ParentImage, ""))
 | eval ho_is_service_event=if(ho_event_id="7045" OR ho_event_id="4697", 1, 0)
 | eval ho_is_service_tooling=if(match(ho_process_image, "\\\\(sc|powershell|pwsh|cmd)\\.exe$"), 1, 0)
 | eval ho_suspicious_service_path=if(
@@ -25,6 +26,9 @@ OR
     OR like(ho_service_path, "%\\programdata\\%")
     OR like(ho_service_path, "%\\public\\%")
     OR like(ho_service_path, "%\\downloads\\%")
+    OR like(ho_service_path, "%\\users\\public\\%")
+    OR like(ho_service_path, "%\\windows\\temp\\%")
+    OR like(ho_service_path, "%\\perflogs\\%")
     OR like(ho_service_path, "%powershell%")
     OR like(ho_service_path, "%pwsh%")
     OR like(ho_service_path, "%cmd.exe%")
@@ -32,7 +36,13 @@ OR
     OR like(ho_service_path, "%regsvr32%")
     OR like(ho_service_path, "%mshta%")
     OR like(ho_service_path, "%wscript%")
-    OR like(ho_service_path, "%cscript%"),
+    OR like(ho_service_path, "%cscript%")
+    OR like(ho_service_path, "%.ps1%")
+    OR like(ho_service_path, "%.vbs%")
+    OR like(ho_service_path, "%.js%")
+    OR like(ho_service_path, "%.hta%")
+    OR like(ho_service_path, "%.bat%")
+    OR like(ho_service_path, "%.cmd%"),
     1, 0)
 | eval ho_suspicious_creation_cli=if(
     like(ho_command_line, "% sc.exe create %")
@@ -42,7 +52,18 @@ OR
     OR like(ho_command_line, "% -encodedcommand%")
     OR like(ho_command_line, "%frombase64string%"),
     1, 0)
+| eval ho_likely_benign_context=if(
+    like(ho_service_path, "%\\program files\\%")
+    OR like(ho_service_path, "%\\program files (x86)\\%")
+    OR like(ho_service_path, "%\\windows\\system32\\drivers\\%")
+    OR match(ho_service_name, "(?i)(update|updater|agent|backup|monitor|driver|print|security|remote|support)"),
+    1, 0)
+| eval ho_tuning_note=case(
+    ho_suspicious_service_path=1, "review service path, signer/vendor context, account, parent process, and maintenance window",
+    ho_suspicious_creation_cli=1, "review service creation command line and requested binPath",
+    ho_likely_benign_context=1, "likely benign context candidate; validate against approved software inventory",
+    true(), "review context before escalation")
 | where (ho_is_service_event=1 AND ho_suspicious_service_path=1)
     OR (ho_is_service_tooling=1 AND ho_suspicious_creation_cli=1)
-| table _time, host, Computer, User, ho_event_id, ho_service_name, ho_service_path, Image, ParentImage, CommandLine
+| table _time, host, Computer, User, ho_event_id, ho_service_name, ho_service_path, Image, ParentImage, CommandLine, ho_parent_image, ho_likely_benign_context, ho_tuning_note
 | sort -_time

--- a/detections/successor/ho-det-011/status.yml
+++ b/detections/successor/ho-det-011/status.yml
@@ -6,34 +6,67 @@ splunk_source_status: SOURCE_EXISTS
 wazuh_source_status: SOURCE_EXISTS
 event_mapping_status: SOURCE_EXISTS
 validation_status: VALIDATION_PLANNED
+tuning_status: SOURCE_TUNING_NOTES_ADDED
 proof_level: SOURCE_EXISTS
 public_safe_status: NOT_PUBLIC_SAFE
 runtime_active: false
 signal_observed: false
 evidence_linked_public_proof: false
 proof_status: BLOCKED
+fixtures_in_detections_repo: false
 canonical_readme: detections/successor/ho-det-011/README.md
 canonical_sigma_source: detections/successor/ho-det-011/rule.yml
 canonical_splunk_source: detections/successor/ho-det-011/splunk.spl
 canonical_wazuh_source: detections/successor/ho-det-011/wazuh.xml
 canonical_event_mapping: detections/successor/ho-det-011/event-mapping.yml
+planned_validation_repo_scope: hawkinsoperations-validation
+planned_validation_fixture_set: REQUIRED_SEPARATE_SCOPE
+planned_platform_case_packet_guardrail: REQUIRED_SEPARATE_SCOPE
+planned_proof_record: REQUIRED_SEPARATE_SCOPE
 telemetry_sources:
   - Windows System Event ID 7045 from Service Control Manager service-install telemetry.
   - Windows Security Event ID 4697 where service-install auditing is enabled.
   - Sysmon Event ID 1 process context for service creation tooling where available.
+tuning_focus:
+  suspicious_fields:
+    - ImagePath
+    - ServiceFileName
+    - CommandLine where available
+    - process image where available
+    - parent process where available
+  suspicious_indicators:
+    - user-writable service image paths
+    - temp/download/public/profile service image paths
+    - interpreter-backed service targets
+    - script-like service targets
+    - service creation command-line patterns
+  benign_review_patterns:
+    - installer and updater services
+    - driver, print, backup, monitoring, security, and remote-support agents
+    - approved endpoint management workflows
+    - known managed application directories
 allowed_claims:
   - HO-DET-011 source artifacts exist.
   - HO-DET-011 is prepared for future synthetic validation.
   - Detection source includes Sigma/SPL/Wazuh/event-mapping/status surfaces.
+  - HO-DET-011 includes source-level tuning notes for suspicious service paths and benign review patterns.
 blocked_claims:
   - runtime-active
   - signal-observed
   - public-safe
   - evidence-linked public proof
   - live Splunk fired
+  - Splunk-fired
   - Wazuh-routed
+  - Cribl-routed
+  - Security Onion observed
+  - Suricata observed
+  - Zeek observed
   - production-ready
   - fleet-wide
+  - autonomous SOC
+  - AI-approved disposition
+  - analyst-approved disposition
   - attack coverage
   - service-creation coverage completeness
   - validation passed

--- a/detections/successor/ho-det-011/wazuh.xml
+++ b/detections/successor/ho-det-011/wazuh.xml
@@ -23,7 +23,7 @@
 
   <rule id="910012" level="10">
     <if_sid>910011</if_sid>
-    <field name="win.eventdata.imagePath" type="pcre2">(?i)(\\AppData\\|\\Temp\\|\\ProgramData\\|\\Public\\|\\Downloads\\|powershell|pwsh|cmd\.exe|rundll32|regsvr32|mshta|wscript|cscript)</field>
+    <field name="win.eventdata.imagePath" type="pcre2">(?i)(\\AppData\\|\\Temp\\|\\ProgramData\\|\\Public\\|\\Downloads\\|\\Users\\Public\\|\\Windows\\Temp\\|\\PerfLogs\\|powershell|pwsh|cmd\.exe|rundll32|regsvr32|mshta|wscript|cscript|\.ps1|\.vbs|\.js|\.hta|\.bat|\.cmd)</field>
     <description>HO-DET-011 candidate: service install with suspicious service image path</description>
     <mitre>
       <id>T1543.003</id>
@@ -32,7 +32,18 @@
     <group>ho-det-011,source-only,validation-planned,blocked-claims-runtime-signal-public,</group>
   </rule>
 
-  <rule id="910013" level="8">
+  <rule id="910013" level="10">
+    <if_sid>910011</if_sid>
+    <field name="win.eventdata.serviceFileName" type="pcre2">(?i)(\\AppData\\|\\Temp\\|\\ProgramData\\|\\Public\\|\\Downloads\\|\\Users\\Public\\|\\Windows\\Temp\\|\\PerfLogs\\|powershell|pwsh|cmd\.exe|rundll32|regsvr32|mshta|wscript|cscript|\.ps1|\.vbs|\.js|\.hta|\.bat|\.cmd)</field>
+    <description>HO-DET-011 candidate: service install with suspicious ServiceFileName value</description>
+    <mitre>
+      <id>T1543.003</id>
+    </mitre>
+    <options>no_full_log</options>
+    <group>ho-det-011,source-only,validation-planned,service-file-name,</group>
+  </rule>
+
+  <rule id="910014" level="8">
     <if_group>windows,sysmon</if_group>
     <field name="win.system.eventID">1</field>
     <field name="win.eventdata.image" type="pcre2">(?i)\\(sc|powershell|pwsh|cmd)\.exe$</field>


### PR DESCRIPTION
This PR upgrades HO-DET-011 into a stronger reviewer-facing detection package.

Scope:
- Clarifies detection behavior and reviewer pivots.
- Clarifies telemetry assumptions for Windows System 7045, Windows Security 4697, and Sysmon Event ID 1.
- Tightens service-event versus process-context condition logic.
- Expands suspicious ImagePath and ServiceFileName coverage.
- Adds Wazuh ServiceFileName coverage.
- Adds Splunk reviewer fields, parent image normalization, and benign-context flagging.
- Adds supported and blocked claim boundaries.
- Adds false-positive/tuning guidance for installers, update tools, driver services, backup/monitoring/security agents, remote-support tools, managed app directories, and approved maintenance windows.

Claim boundary:
This is source and detection-package quality work only.

It does not prove:
- runtime-active status
- signal-observed status
- public-safe proof
- Splunk fired or observed HO-DET-011
- Wazuh routed or observed HO-DET-011
- Cribl routed or preserved HO-DET-011 fields
- Security Onion / Suricata / Zeek observed or corroborated HO-DET-011
- production readiness
- fleet-wide deployment
- autonomous SOC behavior
- AI-approved disposition
- analyst-approved disposition

Validation performed:
- git diff --check
- python scripts/verify_detection_contract.py
- HO-DET-011 YAML parse
- HO-DET-011 Wazuh XML parse
- private/local scan
- blocked-claim scan

Known follow-up:
HO-DET-011 fixture expansion belongs in hawkinsoperations-validation because no HO-DET-011 fixtures were found in this detections repo.