### PR TITLE
[codex] Add HO-DET-001 backend mapping contract

### DIFF
--- a/detections/successor/ho-det-001/event-mapping.yml
+++ b/detections/successor/ho-det-001/event-mapping.yml
@@ -152,7 +152,10 @@ adapter_fields:
     - event_id
     - process_image
     - command_line
-    - marker
+  strict_child_isolation_note: >
+    Controlled marker matching is performed inside the normalized command_line
+    value. The marker is not modeled as a standalone Sysmon or Splunk field in
+    this detection-source mapping contract.
   useful_for_noise_review:
     - parent_image
     - parent_command_line

--- a/detections/successor/ho-det-001/event-mapping.yml
+++ b/detections/successor/ho-det-001/event-mapping.yml
@@ -1,0 +1,176 @@
+detection_id: HO-DET-001
+truth_surface: detection_source
+mapping_status: SOURCE_EXISTS
+validation_status: BACKEND_ADAPTER_PLANNED
+description: >
+  Source-side event mapping for Suspicious PowerShell EncodedCommand Execution.
+  This mapping documents how controlled Sysmon process-creation telemetry can be
+  normalized for backend adapter validation. It does not prove live runtime
+  activity, signal observation, routing, public approval, or production coverage.
+mitre_attack:
+  tactic_ids:
+    - TA0002
+  tactic_names:
+    - Execution
+  technique_ids:
+    - T1059.001
+  technique_names:
+    - PowerShell
+sources:
+  sysmon_event_1:
+    channel: Microsoft-Windows-Sysmon/Operational
+    provider: Sysmon
+    event_id: 1
+    role: process_creation_for_powershell_encoded_command_review
+    expected_fields:
+      event_id:
+        common_names:
+          - EventCode
+          - EventID
+          - event_id
+      process_image:
+        common_names:
+          - Image
+          - process_path
+          - winlog_event_data_Image
+      original_file_name:
+        common_names:
+          - OriginalFileName
+          - winlog_event_data_OriginalFileName
+      command_line:
+        common_names:
+          - CommandLine
+          - ProcessCommandLine
+          - command_line
+          - winlog_event_data_CommandLine
+      parent_image:
+        common_names:
+          - ParentImage
+          - parent_process_path
+          - winlog_event_data_ParentImage
+      parent_command_line:
+        common_names:
+          - ParentCommandLine
+          - parent_command_line
+          - winlog_event_data_ParentCommandLine
+      process_guid:
+        common_names:
+          - ProcessGuid
+          - process_guid
+          - winlog_event_data_ProcessGuid
+      parent_process_guid:
+        common_names:
+          - ParentProcessGuid
+          - parent_process_guid
+          - winlog_event_data_ParentProcessGuid
+      user:
+        common_names:
+          - User
+          - user
+          - winlog_event_data_User
+splunk_fields:
+  canonical_index:
+    default_source_query: windows
+    private_lab_observed: ho_v2_sysmon
+    note: >
+      Backend adapter validation may use private lab index normalization, but
+      source truth remains the detection source and controlled-test fixtures
+      until a separate runtime promotion is approved.
+  sourcetype:
+    candidates:
+      - WinEventLog:Microsoft-Windows-Sysmon/Operational
+      - XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+  source:
+    candidates:
+      - WinEventLog:Microsoft-Windows-Sysmon/Operational
+      - WinEventLog://Microsoft-Windows-Sysmon/Operational
+  event_id:
+    candidates:
+      - EventCode
+      - EventID
+      - event_id
+      - xml.EventID
+  host:
+    candidates:
+      - host
+      - Computer
+  process_image:
+    candidates:
+      - Image
+      - process_path
+      - winlog_event_data_Image
+      - xml.Data.Image
+  original_file_name:
+    candidates:
+      - OriginalFileName
+      - winlog_event_data_OriginalFileName
+      - xml.Data.OriginalFileName
+  command_line:
+    candidates:
+      - CommandLine
+      - ProcessCommandLine
+      - command_line
+      - winlog_event_data_CommandLine
+      - xml.Data.CommandLine
+  parent_image:
+    candidates:
+      - ParentImage
+      - parent_process_path
+      - winlog_event_data_ParentImage
+      - xml.Data.ParentImage
+  parent_command_line:
+    candidates:
+      - ParentCommandLine
+      - parent_command_line
+      - winlog_event_data_ParentCommandLine
+      - xml.Data.ParentCommandLine
+  process_guid:
+    candidates:
+      - ProcessGuid
+      - process_guid
+      - winlog_event_data_ProcessGuid
+      - xml.Data.ProcessGuid
+  parent_process_guid:
+    candidates:
+      - ParentProcessGuid
+      - parent_process_guid
+      - winlog_event_data_ParentProcessGuid
+      - xml.Data.ParentProcessGuid
+  user:
+    candidates:
+      - User
+      - user
+      - winlog_event_data_User
+      - xml.Data.User
+adapter_fields:
+  required_for_behavior_match:
+    - event_id
+    - process_image_or_original_file_name
+    - command_line
+  required_for_strict_child_isolation:
+    - event_id
+    - process_image
+    - command_line
+    - marker
+  useful_for_noise_review:
+    - parent_image
+    - parent_command_line
+    - process_guid
+    - parent_process_guid
+    - user
+adapter_result_labels:
+  - ADAPTER_CONTRACT_PASS
+  - FIELD_EXTRACTION_REQUIRED
+  - PARENT_LAUNCHER_NOISE_SEPARATED
+  - PUBLIC_SAFE_NOT_APPROVED
+claim_boundary:
+  supports:
+    - backend field-normalization planning and deterministic fixture validation
+    - child versus parent launcher noise separation in controlled sanitized cases
+  does_not_support:
+    - runtime-active status
+    - signal-observed public proof
+    - evidence-linked public proof
+    - public-safe proof
+    - production readiness
+    - autonomous disposition

--- a/detections/successor/ho-det-001/event-mapping.yml
+++ b/detections/successor/ho-det-001/event-mapping.yml
@@ -71,11 +71,12 @@ sources:
 splunk_fields:
   canonical_index:
     default_source_query: windows
-    private_lab_observed: ho_v2_sysmon
+    sanitized_lab_index_alias: ho_v2_sysmon
     note: >
-      Backend adapter validation may use private lab index normalization, but
-      source truth remains the detection source and controlled-test fixtures
-      until a separate runtime promotion is approved.
+      Backend adapter validation may use a sanitized lab index alias for
+      deterministic field-normalization tests, but source truth remains the
+      detection source and controlled-test fixtures until a separate runtime
+      promotion is approved.
   sourcetype:
     candidates:
       - WinEventLog:Microsoft-Windows-Sysmon/Operational


### PR DESCRIPTION
## Summary
- Adds the HO-DET-001 source-side backend event mapping contract.
- Documents Sysmon Event ID 1 field aliases used by the later backend adapter validation path.
- Keeps this PR limited to detection-source mapping only.

## Dependency order
This PR should merge before the validation adapter PR. The validation verifier reads hawkinsoperations-detections/detections/successor/ho-det-001/event-mapping.yml from the detections repo default branch during CI, so validation packaging should wait until this mapping is on main.

## Claim boundary
- No runtime-active detection claim.
- No signal-observed public proof claim.
- No evidence-linked public proof claim.
- No public-safe proof promotion.
- No production readiness claim.
- No autonomous or AI-approved disposition claim.

## Validation
- git diff --cached --check passed before commit.
- YAML parse check passed for detection_id HO-DET-001 and technique T1059.001.

## Follow-up
After this PR merges, open the validation PR for the normalizer, backend verifier, sanitized runtime-shaped cases, and CI wiring.