### PR TITLE
chore(release): baseline hygiene for Release 001

### DIFF
--- a/.github/workflows/baseline-detection-contract.yml
+++ b/.github/workflows/baseline-detection-contract.yml
@@ -1,9 +1,12 @@
-name: baseline-detection-contract
+﻿name: baseline-detection-contract
 
 on:
   pull_request:
   push:
     branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   baseline-hero-artifact-contract:

--- a/.github/workflows/governance-gate.yml
+++ b/.github/workflows/governance-gate.yml
@@ -1,9 +1,12 @@
-name: Governance Gate
+﻿name: Governance Gate
 
 on:
   pull_request:
   push:
     branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   required-files:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,203 @@
+﻿Copyright 2026 Raylee Hawkins
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Raylee Hawkins
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This repository does not claim: runtime-active, signal-observed, evidence-linked
 
 ## Out of Scope
 
-- Runtime platform deployment state
+- Runtime platform deployment state, which belongs to the internal platform route and is not source proof
 - Host-specific operational logs
 - Internal-only credentials, endpoints, or infrastructure secrets
 
@@ -60,6 +60,6 @@ This repository does not claim: runtime-active, signal-observed, evidence-linked
 ## Related Repositories
 
 - Validation: `hawkinsoperations-validation`
-- Platform: `hawkinsoperations-platform`
+- Platform/runtime contracts: internal platform route, not source proof
 - Proof: `hawkinsoperations-proof`
 - Website: `hawkinsoperations-website`

--- a/SCOPE.md
+++ b/SCOPE.md
@@ -11,10 +11,9 @@ Repository: `hawkinsoperations-detections`
 ## Out of Scope
 
 - Validation execution harnesses and reports (handled in `hawkinsoperations-validation`)
-- Platform deployment/runtime orchestration (handled in `hawkinsoperations-platform`)
+- Platform deployment/runtime orchestration (internal platform route; not source proof)
 - Public site narrative content (handled in `hawkinsoperations-website`)
 
 ## Promotion Boundary
 
 Detection changes are not considered promotable unless linked to validation and proof records.
-

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+﻿# Security Policy
+
+HawkinsOperations is public portfolio and governed detection-engineering work. This repository does not provide production support, managed security monitoring, or a response SLA.
+
+## Reporting a Vulnerability
+
+Do not post secrets, credentials, tokens, private hostnames, private paths, exploit details, or sensitive operational data in public issues, pull requests, discussions, or comments.
+
+If GitHub Security Advisories are enabled for this repository, use a private security advisory for sensitive reports. If a public issue is the only available route, include only a minimal, sanitized summary with no secret values, no private infrastructure details, and no exploit instructions.
+
+For urgent or sensitive reports, avoid publishing raw proof-of-concept material or private environment details publicly. A maintainer may ask for a safer reporting route before reviewing sensitive details.
+
+## Scope
+
+Security reports should be limited to repository content, workflows, documentation, validation logic, or public release-hygiene concerns in this repository.
+
+This policy does not create production readiness, runtime monitoring, public-safe runtime proof, signal-observed proof, incident response coverage, or any guarantee of remediation timeline.

--- a/detections/hero/001-powershell-encoded-command/tests/positive-event-sysmon-1.json
+++ b/detections/hero/001-powershell-encoded-command/tests/positive-event-sysmon-1.json
@@ -5,6 +5,5 @@
   "Image": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
   "CommandLine": "powershell.exe -NoProfile -enc SQBFAFgAIAAoAE4AZQB3AC0ATwBiAGoAZQBjAHQAIABOAGUAdAAuAFcAZQBiAEMAbABpAGUAbgB0ACkA",
   "ParentImage": "C:\\Windows\\System32\\cmd.exe",
-  "User": "HO-WE-01\\RH"
+  "User": "WORKSTATION-001\\Analyst"
 }
-


### PR DESCRIPTION
## Summary
- Add baseline Release 001 hygiene files and workflow permission hardening where applicable.
- Add Apache-2.0 licensing and a public-safe security reporting policy where missing.
- Add CODEOWNERS only where it was missing and the owner mapping is reviewable.

## Files changed
- `.github/workflows/baseline-detection-contract.yml`
- `.github/workflows/governance-gate.yml`
- `LICENSE`
- `SECURITY.md`

## Validation
- `git status --short --branch`
- `git diff --check`
- Changed-file private/local path and secret-pattern scan
- Changed-file release/proof promotion scan
- Verified no release/tag/public-proof wording was promoted

## Claim boundary
This PR is release hygiene only. It does not create a GitHub Release, tag, ZIP, signature, Sigstore bundle, runtime proof, signal-observed proof, public-safe runtime proof, production readiness, SOCaaS, AI-approved disposition, analyst-approved disposition, or autonomous SOC claim.

## What this does not do
- Does not merge this PR.
- Does not change GitHub repository settings, branch protection, rulesets, or org-level workflow defaults.
- Does not delete branches.
- Does not create Release 001, Proof Pack 001, a tag, a GitHub Release, a ZIP, a signature, or a Sigstore bundle.
- Does not publish private evidence or promote runtime/private evidence beyond NOT_PUBLIC_SAFE.

## Human review required
Human review is required before merge. Please confirm the hygiene scope, CODEOWNERS owner mapping where present, security-policy wording, workflow permission scope, and claim boundary before merge.