### PR TITLE
fix(detection): reconcile HO-DET-012 proof boundary

### DIFF
--- a/detections/DETECTION_PROMOTION_MATRIX.yml
+++ b/detections/DETECTION_PROMOTION_MATRIX.yml
@@ -278,8 +278,8 @@ entries:
       - live Security Onion proof
       - production-ready
       - fleet-wide
-    next_gate: proof status index before website or public-route parity
-    notes: Controlled-test validation is external validation truth, not source proof.
+    next_gate: proof record creation under separate proof scope; runtime, signal, and public-safe promotion remain blocked
+    notes: Controlled-test validation is external validation truth. Proof index currently records NO_PROOF_RECORD for HO-DET-012; this matrix does not create a proof record.
 
   - detection_id: HO-DET-013
     package_path: detections/successor/ho-det-013

--- a/detections/successor/ho-det-012/README.md
+++ b/detections/successor/ho-det-012/README.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-HO-DET-012 defines source artifacts for suspicious Windows scheduled task creation, registration, or update behavior. This folder prepares the detection source for future controlled-test validation across Sigma-style YAML, Splunk SPL, Wazuh XML, event mapping, and status metadata.
+HO-DET-012 defines source artifacts for suspicious Windows scheduled task creation, registration, or update behavior. This folder preserves the detection source and controlled-test validation boundary across Sigma-style YAML, Splunk SPL, Wazuh XML, event mapping, and status metadata.
 
-This source does not prove runtime activity, signal observation, validation passage, public-safe proof, routed telemetry, or production readiness.
+This source does not prove runtime activity, signal observation, public proof, public-safe proof, routed telemetry, or production readiness.
 
 ## Scope
 
@@ -46,7 +46,7 @@ Suspicious task names are weak review context only. Updater-like names, one-char
 - `splunk.spl` provides a Splunk source query candidate.
 - `wazuh.xml` provides a Wazuh XML source candidate.
 - `event-mapping.yml` maps expected fields across Windows Security 4698/4702, TaskScheduler Operational 106/140, Sysmon Event ID 1, Splunk, and Wazuh.
-- `status.yml` records the source-only truth boundary.
+- `status.yml` records the source, validation, and proof-boundary truth split.
 
 ## Telemetry Requirements
 
@@ -83,29 +83,30 @@ Tuning should not suppress user-writable task actions, interpreter-backed task a
 
 ## Validation Boundary
 
-Validation is planned, not complete. Future validation should use controlled positive and negative fixtures that distinguish benign scheduled-task creation from suspicious action, path, or tooling patterns.
+HO-DET-012 has source artifacts in this repo and controlled validation in `hawkinsoperations-validation`. The validation report supports `CONTROLLED_TEST_VALIDATED` for 8 controlled scheduled-task fixtures: 4 positive, 4 negative, 0 missed positives, and 0 false-positive negatives.
 
 No HO-DET-012 fixtures were created in this detections repository. Fixture expansion belongs in a separately scoped `hawkinsoperations-validation` lane unless fixture paths are later added to this repository.
 
-Suggested future fixture coverage:
+Current controlled fixture coverage:
 
 - Positive Windows Security 4698 task creation using a suspicious action under AppData.
 - Positive TaskScheduler Operational 106 registration using an interpreter-backed action.
 - Positive Sysmon Event ID 1 process context using `schtasks.exe /create` with a suspicious `/tr` target.
 - Positive PowerShell process context using `Register-ScheduledTask` and `New-ScheduledTaskAction`.
 - Negative benign vendor updater task under Program Files.
-- Negative endpoint management, backup, monitoring, security, or remote-support task.
+- Negative endpoint management task under a managed application directory.
 - Negative approved maintenance-window task creation.
 - Negative suspicious-looking task name without suspicious action, path, or tooling evidence.
 
 ## Supported Claims
 
-This package supports only these source-quality claims:
+This package supports only these controlled source and validation claims:
 
 - HO-DET-012 source artifacts exist in this repository.
-- HO-DET-012 is prepared for future controlled-test validation.
+- HO-DET-012 passed controlled-test validation against scheduled-task creation and update fixtures.
 - Detection source includes Sigma/SPL/Wazuh/event-mapping/status surfaces.
 - HO-DET-012 documents scheduled-task telemetry assumptions and false-positive review guidance.
+- HO-DET-012 has no proof record in `hawkinsoperations-proof` in this phase.
 
 ## Blocked Claims
 
@@ -131,8 +132,8 @@ This source must not be cited as evidence for:
 - analyst-approved disposition
 - attack coverage completeness
 - scheduled-task coverage completeness
-- validation passed
+- proof record availability
 
 ## Next Gate
 
-The next gate is a validation-repo fixture set and deterministic controlled-test validation harness for HO-DET-012. That work must be scoped separately and must not be inferred from these source files.
+The next gates are proof record creation, runtime evidence, signal evidence, and public-proof review under separate approval. Controlled validation is satisfied for the current fixture scope.

--- a/detections/successor/ho-det-012/event-mapping.yml
+++ b/detections/successor/ho-det-012/event-mapping.yml
@@ -1,11 +1,12 @@
 detection_id: HO-DET-012
 truth_surface: detection_source
 mapping_status: SOURCE_EXISTS
-validation_status: VALIDATION_PLANNED
+validation_status: CONTROLLED_TEST_VALIDATED
 description: >
-  Source-only event mapping for suspicious Windows scheduled task creation or
-  update behavior. This mapping prepares future controlled-test validation and does
-  not prove runtime activity, signal observation, routing, public-safe status, or evidence-linked public proof claims.
+  Event mapping for suspicious Windows scheduled task creation or update
+  behavior. This mapping supports controlled-test validation and does not prove
+  runtime activity, signal observation, routing, public-safe status, proof record
+  availability, or evidence-linked public proof claims.
 telemetry_boundary:
   windows_security_4698: Windows Security Event ID 4698 may record scheduled task creation where audit policy and collection support it.
   windows_security_4702: Windows Security Event ID 4702 may record scheduled task update where audit policy and collection support it.
@@ -188,7 +189,11 @@ tuning_fields:
     - approved maintenance window
 validation_fixture_boundary:
   detections_repo_fixtures_found: false
-  validation_repo_fixture_set: REQUIRED_SEPARATE_SCOPE
+  validation_repo_fixture_set: SATISFIED_FOR_CURRENT_CONTROLLED_TEST_SCOPE
+proof_boundary:
+  proof_status: NO_PROOF_RECORD
+  proof_record_path: null
+  public_safe_status: NOT_PUBLIC_SAFE
 blocked_claims:
   - runtime-active
   - signal-observed
@@ -210,4 +215,4 @@ blocked_claims:
   - analyst-approved disposition
   - attack coverage completeness
   - scheduled-task coverage completeness
-  - validation passed
+  - proof record availability

--- a/detections/successor/ho-det-012/rule.yml
+++ b/detections/successor/ho-det-012/rule.yml
@@ -1,21 +1,22 @@
 title: HO-DET-012 Suspicious Scheduled Task Creation
 detection_id: HO-DET-012
-status: experimental/source-only
-proof_level: SOURCE_EXISTS
-trust_class: SOURCE_EXISTS
+status: experimental/controlled-test-validated
+proof_level: CONTROLLED_TEST_VALIDATED
+trust_class: CONTROLLED_TEST_VALIDATED
 public_safe_status: NOT_PUBLIC_SAFE
 approval_status: NOT_APPROVED
 runtime_active: "NO"
-validation_status: VALIDATION_PLANNED
+validation_status: CONTROLLED_TEST_VALIDATED
 signal_observed: "NO"
 evidence_linked: "NO"
+proof_status: NO_PROOF_RECORD
 description: >
   Sigma-style source artifact for suspicious Windows scheduled task creation,
   registration, or update behavior. This source uses Windows Security Event IDs
   4698 and 4702 where audit policy records scheduled task changes,
   Microsoft-Windows-TaskScheduler/Operational Event IDs 106 and 140 where the
   operational log is enabled and collected, and Sysmon Event ID 1 process
-  context where available. It does not establish runtime, signal, validation, routing, or public-safe proof claims.
+  context where available. It does not establish runtime, signal, proof record, routing, or public-safe proof claims.
 author: HawkinsOperations
 date: 2026-05-11
 references:
@@ -158,7 +159,7 @@ tuning_guidance:
     - Backup, monitoring, security, endpoint management, and remote-support agents.
     - Known managed application paths and approved maintenance windows.
 level: medium
-allowed_claim: HO-DET-012 source artifacts exist and are prepared for future controlled-test validation.
+allowed_claim: HO-DET-012 source artifacts exist and controlled-test validation passed for scheduled-task creation and update fixtures.
 blocked_claims:
   - runtime-active
   - signal-observed
@@ -180,11 +181,11 @@ blocked_claims:
   - analyst-approved disposition
   - attack coverage completeness
   - scheduled-task coverage completeness
-  - validation passed
+  - proof record availability
 promotion_boundaries:
   source_exists_supports:
     - HO-DET-012 source artifacts exist in this repository path.
-    - HO-DET-012 is prepared for future controlled-test validation.
+    - HO-DET-012 passed controlled-test validation against scheduled-task creation and update fixtures.
   source_exists_does_not_support:
     - runtime-active status
     - signal-observed status
@@ -192,7 +193,7 @@ promotion_boundaries:
     - public-safe status
     - live Splunk firing
     - Wazuh-routed telemetry
-    - validation passage
+    - proof record availability
 validation_fixture_boundary:
   detections_repo_fixtures_found: false
-  validation_repo_fixture_set: REQUIRED_SEPARATE_SCOPE
+  validation_repo_fixture_set: SATISFIED_FOR_CURRENT_CONTROLLED_TEST_SCOPE

--- a/detections/successor/ho-det-012/status.yml
+++ b/detections/successor/ho-det-012/status.yml
@@ -15,12 +15,14 @@ validation_matched_positive_count: 4
 validation_missed_positives: 0
 validation_false_positive_negatives: 0
 tuning_status: SOURCE_TUNING_NOTES_ADDED
-proof_level: SOURCE_EXISTS
+claim_ceiling: CONTROLLED_TEST_VALIDATED
+proof_level: CONTROLLED_TEST_VALIDATED
 public_safe_status: NOT_PUBLIC_SAFE
 runtime_active: false
 signal_observed: false
 evidence_linked_public_proof: false
-proof_status: BLOCKED
+proof_status: NO_PROOF_RECORD
+proof_record_path: null
 fixtures_in_detections_repo: false
 canonical_readme: detections/successor/ho-det-012/README.md
 canonical_sigma_source: detections/successor/ho-det-012/rule.yml
@@ -109,4 +111,6 @@ next_gate:
   controlled_test_validation_harness: SATISFIED_FOR_CURRENT_CONTROLLED_TEST_SCOPE
   platform_status_visibility: REQUIRED_SEPARATE_SCOPE
   runtime_evidence: BLOCKED
+  signal_evidence: BLOCKED
+  proof_record: NO_PROOF_RECORD
   public_proof: BLOCKED


### PR DESCRIPTION
Summary:
- Aligns HO-DET-012 detection-side docs/status with controlled validation and proof-boundary truth.
- Preserves CONTROLLED_TEST_VALIDATED only for controlled scheduled-task validation.
- Records the no-proof-record boundary without creating or implying a proof record.
- Keeps runtime, signal, public-safe proof, routed proof, production, autonomous SOC, and AI/analyst disposition claims blocked.
- Updates only HO-DET-012 files and the HO-DET-012 promotion matrix note.

Validation:
- python scripts/verify_detection_promotion_matrix.py
- python scripts/verify_detection_contract.py
- git diff --check

Claim boundary:
- Controlled validation only.
- No runtime-active claim.
- No signal-observed claim.
- No public-safe runtime claim.
- No live Splunk/Wazuh/Cribl/Security Onion proof claim.
- No production deployment claim.
- No autonomous SOC claim.
- No AI-approved or analyst-approved disposition claim.
- No proof record created.