### PR TITLE
docs(detections): reference cyber kill chain coverage map

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository contains detection logic as source content. It is the authoring 
 - Build loud. Verify hard. Claim tight. Ship receipts.
 - Website/public pages route to proof records; they do not replace proof.
 - Next gates: case packet spine, deterministic verifier, claim-boundary scanner, CI proof-loop, proof card, website route.
+- Cyber Kill Chain coverage: this repo contributes detection source truth to the canonical [Cyber Kill Chain coverage map](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/docs/mappings/CYBER_KILL_CHAIN_COVERAGE.md) in `hawkinsoperations-proof`. The map is reviewer navigation, not runtime, signal, production, or public-safe proof authority.
 
 ## Blocked Claims
 


### PR DESCRIPTION
Summary:
- Adds pointer to canonical proof artifact.
- Does not duplicate the artifact.
- Does not promote runtime/signal/public-safe/production claims.
- Website untouched.

Validation:
- git diff --check
- python scripts/verify_detection_promotion_matrix.py
- python scripts/verify_detection_contract.py

Claim boundary:
- Canonical artifact remains in hawkinsoperations-proof.
- This repo contributes detection source truth and is not proof authority.
- No runtime-active, signal-observed, public-safe runtime, production-ready, autonomous SOC, AI-approved, or analyst-approved claim is promoted.