### PR TITLE
docs(detection): align HO-DET-012 proof status metadata

### DIFF
--- a/detections/successor/ho-det-012/status.yml
+++ b/detections/successor/ho-det-012/status.yml
@@ -39,7 +39,7 @@ canonical_claim_boundary_scanner: hawkinsoperations-validation/scripts/scan-ho-d
 canonical_validation_workflow: hawkinsoperations-validation/.github/workflows/ho-det-012-fixture-loop.yml
 planned_validation_fixture_set: SATISFIED_FOR_CURRENT_CONTROLLED_TEST_SCOPE
 planned_platform_case_packet_guardrail: REQUIRED_SEPARATE_SCOPE
-planned_proof_record: REQUIRED_SEPARATE_SCOPE
+planned_proof_record: SATISFIED_FOR_CURRENT_CONTROLLED_TEST_SCOPE
 mitre_attack:
   primary_technique: T1053.005
   primary_technique_name: Scheduled Task


### PR DESCRIPTION
Aligns HO-DET-012 detection source metadata with current proof truth.

This PR changes only detections/successor/ho-det-012/status.yml.

Boundary preserved:
- proof status remains CONTROLLED_TEST_VALIDATED
- runtime remains NOT_PROVEN
- signal remains NOT_PROVEN
- public-safe remains NOT_PUBLIC_SAFE
- no runtime-active, public signal, public-safe runtime, production, fleet-wide, autonomous SOC, AI-approved, or analyst-approved claim is promoted
- no runtime evidence is created
- no proof or website files are changed

Validation:
- validate-ho-det-012.py
- verify-ho-det-012-result-parity.py
- scan-ho-det-012-claim-boundaries.py
- verify_detection_proof_status_index.py
- ho_factory.py status --detection HO-DET-012
- git diff --check