### PR TITLE
docs: add detection ledger eligibility map

### DIFF
--- a/detections/DETECTION_FACTORY_INDEX.md
+++ b/detections/DETECTION_FACTORY_INDEX.md
@@ -54,6 +54,24 @@ Only the following truth states are used in this index:
 
 A higher state is never inferred from a lower one. State changes require evidence and approval routed through the appropriate repository.
 
+## Detection-Side Ledger Eligibility
+
+This section classifies detection-side ledger and reviewer expansion posture. It is source-truth metadata only. It does not append entries to `evidence/evidence-ledger.json`, does not claim canonical ledger state, does not create validation truth, does not create runtime or signal truth, and does not promote public-safe proof. Platform-owned ledger systems remain the authority for canonical Lifetime Case Ledger truth; this detections repo owns only source-side eligibility and readiness metadata.
+
+`APPENDED` is empty because this repo has no source-side eligibility append records. Canonical Lifetime Case Ledger append truth belongs to platform-owned ledger systems. `PROOF_RECORDED` means a separate proof-record route exists; it does not mean the detection-side metadata was appended to a canonical ledger. `DRY_RUN_READY` means source and controlled-test validation exist and a reviewer route can be dry-run without stronger claims. `VALIDATION_READY` means source exists and validation is the next gate. `BLOCKED` means current evidence or repo-boundary state blocks reviewer expansion. `NEEDS_TELEMETRY_CONTRACT` means telemetry-field or route contract work must precede source/validation expansion. `FUTURE_CANDIDATE` means planned only.
+
+| Ledger eligibility | Detection IDs | Reviewer expansion posture |
+|---|---|---|
+| `APPENDED` | none | No source-side eligibility append records are recorded in this detections metadata. |
+| `DRY_RUN_READY` | `ID-DET-001`, `ID-DET-002`, `ID-DET-003`, `ID-DET-004` | Identity detections have source and controlled-test validation; proof records, live IdP evidence, runtime, signal, and public-safe claims remain separate gates. |
+| `VALIDATION_READY` | `HO-DET-013` | Source package exists; controlled telemetry/security-control tamper fixture validation is the next gate. |
+| `PROOF_RECORDED` | `HOD-001`, `HO-DET-001`, `HO-DET-011`, `HO-DET-012`, `AWS-DET-001` | Proof-record routes exist; they preserve their own claim ceilings and do not imply detection-side ledger append, runtime, signal, or public-safe proof. |
+| `BLOCKED` | `HO-NDR-001` | Boundary contract is external to this source repo; runtime packet, evidence route, and public wording review are required before reviewer expansion. |
+| `NEEDS_TELEMETRY_CONTRACT` | `HO-DET-014`, `HO-DET-015`, `HO-DET-016`, `HO-NDR-002`, `HO-PIPE-001` | Telemetry-field, route, or event contract work must precede source/validation expansion or ledger dry-run. |
+| `FUTURE_CANDIDATE` | `HO-DET-002`, `HO-DET-003`, `HO-DET-004`, `HO-DET-005`, `HO-DET-006`, `HO-DET-007`, `HO-DET-008`, `HO-DET-009`, `HO-DET-010` | Planned candidates only; no source package is claimed to exist. |
+
+The machine-readable classification and per-detection reviewer expansion actions live in `detections/DETECTION_PROMOTION_MATRIX.yml` and are enforced by `scripts/verify_detection_promotion_matrix.py`.
+
 ## Detection Factory Matrix
 
 | ID | Detection | Detection surface | Artifact format | Primary telemetry source | Current truth state | Existing artifact | Next source artifact | Next validation gate | Next runtime/evidence gate | Blocked claims |

--- a/detections/DETECTION_PROMOTION_MATRIX.yml
+++ b/detections/DETECTION_PROMOTION_MATRIX.yml
@@ -22,6 +22,178 @@ allowed_status_values:
     - false
   signal_observed:
     - false
+ledger_boundary:
+  detections_repo_scope: SOURCE_SIDE_ELIGIBILITY_AND_READINESS_METADATA_ONLY
+  canonical_lifetime_case_ledger_owner: hawkinsoperations-platform
+  does_not_claim_canonical_ledger_state: true
+  does_not_append_ledger_entries: true
+ledger_eligibility_status_values:
+  - APPENDED
+  - DRY_RUN_READY
+  - VALIDATION_READY
+  - PROOF_RECORDED
+  - BLOCKED
+  - NEEDS_TELEMETRY_CONTRACT
+  - FUTURE_CANDIDATE
+detection_side_ledger_eligibility:
+  appended: []
+  dry_run_ready:
+    - ID-DET-001
+    - ID-DET-002
+    - ID-DET-003
+    - ID-DET-004
+  validation_ready:
+    - HO-DET-013
+  proof_recorded:
+    - HOD-001
+    - HO-DET-001
+    - HO-DET-011
+    - HO-DET-012
+    - AWS-DET-001
+  blocked:
+    - HO-NDR-001
+  needs_telemetry_contract:
+    - HO-DET-014
+    - HO-DET-015
+    - HO-DET-016
+    - HO-NDR-002
+    - HO-PIPE-001
+  future_candidate:
+    - HO-DET-002
+    - HO-DET-003
+    - HO-DET-004
+    - HO-DET-005
+    - HO-DET-006
+    - HO-DET-007
+    - HO-DET-008
+    - HO-DET-009
+    - HO-DET-010
+reviewer_expansion_map:
+  - detection_id: HOD-001
+    ledger_eligibility_status: PROOF_RECORDED
+    reviewer_lane: Legacy hero baseline reference
+    reviewer_summary: Hero baseline proof record exists, but successor HO-DET-001 remains the current reviewed package.
+    next_reviewer_action: Preserve as baseline continuity; do not treat as new ledger append or current runtime proof.
+  - detection_id: HO-DET-001
+    ledger_eligibility_status: PROOF_RECORDED
+    reviewer_lane: Closed loop endpoint receipt
+    reviewer_summary: Successor PowerShell package has controlled-test validation and a proof record.
+    next_reviewer_action: Use proof route for reviewer navigation; do not append new evidence without separate evidence review.
+  - detection_id: HO-DET-002
+    ledger_eligibility_status: FUTURE_CANDIDATE
+    reviewer_lane: Endpoint process expansion
+    reviewer_summary: Planned PowerShell flag and hidden execution candidate with no source package claimed.
+    next_reviewer_action: Author source package only under separate detection-source approval.
+  - detection_id: HO-DET-003
+    ledger_eligibility_status: FUTURE_CANDIDATE
+    reviewer_lane: Endpoint living-off-the-land expansion
+    reviewer_summary: Planned certutil download/decode candidate with no source package claimed.
+    next_reviewer_action: Author source package and fixture plan under separate source and validation scopes.
+  - detection_id: HO-DET-004
+    ledger_eligibility_status: FUTURE_CANDIDATE
+    reviewer_lane: Endpoint living-off-the-land expansion
+    reviewer_summary: Planned bitsadmin transfer candidate with no source package claimed.
+    next_reviewer_action: Keep as roadmap candidate until source package approval exists.
+  - detection_id: HO-DET-005
+    ledger_eligibility_status: FUTURE_CANDIDATE
+    reviewer_lane: Endpoint script proxy expansion
+    reviewer_summary: Planned mshta candidate with no source package claimed.
+    next_reviewer_action: Keep as roadmap candidate until source package approval exists.
+  - detection_id: HO-DET-006
+    ledger_eligibility_status: FUTURE_CANDIDATE
+    reviewer_lane: Endpoint script proxy expansion
+    reviewer_summary: Planned rundll32 suspicious script/proxy candidate with no source package claimed.
+    next_reviewer_action: Keep as roadmap candidate until source package approval exists.
+  - detection_id: HO-DET-007
+    ledger_eligibility_status: FUTURE_CANDIDATE
+    reviewer_lane: Endpoint scriptlet expansion
+    reviewer_summary: Planned regsvr32 scriptlet candidate with no source package claimed.
+    next_reviewer_action: Keep as roadmap candidate until source package approval exists.
+  - detection_id: HO-DET-008
+    ledger_eligibility_status: FUTURE_CANDIDATE
+    reviewer_lane: Endpoint parent-child expansion
+    reviewer_summary: Planned suspicious child-process candidate with no source package claimed.
+    next_reviewer_action: Keep as roadmap candidate until source and mapping approval exists.
+  - detection_id: HO-DET-009
+    ledger_eligibility_status: FUTURE_CANDIDATE
+    reviewer_lane: Windows account lifecycle expansion
+    reviewer_summary: Planned local user creation candidate with no source package claimed.
+    next_reviewer_action: Keep as roadmap candidate until Event ID mapping, Wazuh XML, and SPL source approval exists.
+  - detection_id: HO-DET-010
+    ledger_eligibility_status: FUTURE_CANDIDATE
+    reviewer_lane: Windows privilege expansion
+    reviewer_summary: Planned local administrators group change candidate with no source package claimed.
+    next_reviewer_action: Keep as roadmap candidate until Event ID mapping, Wazuh XML, and SPL source approval exists.
+  - detection_id: HO-DET-011
+    ledger_eligibility_status: PROOF_RECORDED
+    reviewer_lane: Windows service persistence
+    reviewer_summary: Source, controlled validation, private runtime boundary, and proof record are recorded; public-safe status remains blocked.
+    next_reviewer_action: Route reviewers to proof record and require evidence-link/redaction review before stronger public wording.
+  - detection_id: HO-DET-012
+    ledger_eligibility_status: PROOF_RECORDED
+    reviewer_lane: Scheduled task persistence
+    reviewer_summary: Source, controlled validation, and proof record are recorded for controlled-test scope.
+    next_reviewer_action: Route reviewers to proof record; keep runtime, signal, and public-safe claims blocked.
+  - detection_id: HO-DET-013
+    ledger_eligibility_status: VALIDATION_READY
+    reviewer_lane: Endpoint tamper expansion
+    reviewer_summary: Source package exists and validation is planned; no controlled-test result is claimed here.
+    next_reviewer_action: Build controlled-test telemetry/security-control tamper fixture set in validation repo under separate scope.
+  - detection_id: HO-DET-014
+    ledger_eligibility_status: NEEDS_TELEMETRY_CONTRACT
+    reviewer_lane: Linux auth expansion
+    reviewer_summary: Planned sudo/root command candidate needs auth/audit field contract before source and validation claims.
+    next_reviewer_action: Define telemetry contract before source authoring or ledger dry-run.
+  - detection_id: HO-DET-015
+    ledger_eligibility_status: NEEDS_TELEMETRY_CONTRACT
+    reviewer_lane: Wazuh operations expansion
+    reviewer_summary: Planned Wazuh agent lifecycle candidate needs manager-event telemetry contract before source and validation claims.
+    next_reviewer_action: Define manager event contract before source authoring or ledger dry-run.
+  - detection_id: HO-DET-016
+    ledger_eligibility_status: NEEDS_TELEMETRY_CONTRACT
+    reviewer_lane: Honeypot visibility expansion
+    reviewer_summary: Planned Cowrie candidate needs event-field contract before source and validation claims.
+    next_reviewer_action: Define Cowrie event contract before source authoring or ledger dry-run.
+  - detection_id: ID-DET-001
+    ledger_eligibility_status: DRY_RUN_READY
+    reviewer_lane: Identity session expansion
+    reviewer_summary: Source and controlled-test validation exist; proof record and runtime/IdP evidence remain separate gates.
+    next_reviewer_action: Dry-run reviewer proof/ledger route without claiming live IdP, runtime, or public-safe proof.
+  - detection_id: ID-DET-002
+    ledger_eligibility_status: DRY_RUN_READY
+    reviewer_lane: Identity MFA expansion
+    reviewer_summary: Source and controlled-test validation exist; proof record and runtime/IdP evidence remain separate gates.
+    next_reviewer_action: Dry-run reviewer proof/ledger route without claiming live IdP, runtime, or public-safe proof.
+  - detection_id: ID-DET-003
+    ledger_eligibility_status: DRY_RUN_READY
+    reviewer_lane: Identity privilege expansion
+    reviewer_summary: Source and controlled-test validation exist; proof record and runtime/IdP evidence remain separate gates.
+    next_reviewer_action: Dry-run reviewer proof/ledger route without claiming live IdP, runtime, or public-safe proof.
+  - detection_id: ID-DET-004
+    ledger_eligibility_status: DRY_RUN_READY
+    reviewer_lane: Identity anomaly expansion
+    reviewer_summary: Source and controlled-test validation exist; proof record and runtime/IdP evidence remain separate gates.
+    next_reviewer_action: Dry-run reviewer proof/ledger route without claiming live IdP, runtime, completeness, or public-safe proof.
+  - detection_id: AWS-DET-001
+    ledger_eligibility_status: PROOF_RECORDED
+    reviewer_lane: Cloud fixture expansion
+    reviewer_summary: CloudTrail-style fixture source, controlled validation, and proof record exist; AWS-live remains blocked.
+    next_reviewer_action: Use proof route for fixture scope only; require live CloudTrail approval before runtime wording.
+  - detection_id: HO-NDR-001
+    ledger_eligibility_status: BLOCKED
+    reviewer_lane: NDR boundary scaffold
+    reviewer_summary: Boundary contract exists outside this source repo, but no published detections repo source package or runtime observation is claimed.
+    next_reviewer_action: Keep blocked until separate runtime packet, evidence route, and public wording review are approved.
+  - detection_id: HO-NDR-002
+    ledger_eligibility_status: NEEDS_TELEMETRY_CONTRACT
+    reviewer_lane: NDR scan visibility expansion
+    reviewer_summary: Planned Suricata/Zeek candidate needs telemetry and field contract before source and validation claims.
+    next_reviewer_action: Define NDR telemetry contract before source authoring or ledger dry-run.
+  - detection_id: HO-PIPE-001
+    ledger_eligibility_status: NEEDS_TELEMETRY_CONTRACT
+    reviewer_lane: Pipeline route integrity
+    reviewer_summary: Source-controlled route contract exists, but live delivery, marker, and downstream signal claims require separate telemetry contract review.
+    next_reviewer_action: Define runtime route receipt contract before platform-ledger append review, proof expansion, or public wording.
 entries:
   - detection_id: HOD-001
     package_path: detections/hero/001-powershell-encoded-command

--- a/scripts/verify_detection_promotion_matrix.py
+++ b/scripts/verify_detection_promotion_matrix.py
@@ -44,6 +44,34 @@ ALLOWED_PROOF_CEILING = {
     "BOUNDARY_CONTRACT_ONLY",
 }
 
+ALLOWED_LEDGER_ELIGIBILITY_STATUS = {
+    "APPENDED",
+    "DRY_RUN_READY",
+    "VALIDATION_READY",
+    "PROOF_RECORDED",
+    "BLOCKED",
+    "NEEDS_TELEMETRY_CONTRACT",
+    "FUTURE_CANDIDATE",
+}
+
+LEDGER_ELIGIBILITY_BUCKETS = {
+    "appended": "APPENDED",
+    "dry_run_ready": "DRY_RUN_READY",
+    "validation_ready": "VALIDATION_READY",
+    "proof_recorded": "PROOF_RECORDED",
+    "blocked": "BLOCKED",
+    "needs_telemetry_contract": "NEEDS_TELEMETRY_CONTRACT",
+    "future_candidate": "FUTURE_CANDIDATE",
+}
+
+REVIEWER_EXPANSION_REQUIRED_FIELDS = {
+    "detection_id",
+    "ledger_eligibility_status",
+    "reviewer_lane",
+    "reviewer_summary",
+    "next_reviewer_action",
+}
+
 LOCAL_SOURCE_STATUSES = {"SOURCE_EXISTS", "BOUNDARY_CONTRACT_ONLY"}
 PLANNED_OR_EXTERNAL_STATUSES = {"VALIDATION_PLANNED", "EXTERNAL_BOUNDARY_CONTRACT"}
 
@@ -72,6 +100,7 @@ ALLOWED_CLAIM_CONTEXT_RE = re.compile(
     r"out of scope|excluded|without claiming|must not|no live|no .*claim|proof remains|"
     r"not promote|does not promote|source-only|source truth only)"
 )
+POSITIVE_PROMOTION_RE = re.compile(r"(?i)\b(now has|has|is|are|supports|promotes|promoted)\b")
 
 
 class MatrixError(Exception):
@@ -195,18 +224,38 @@ def is_local_path(package_path: str) -> bool:
     return "://" not in package_path
 
 
+def scan_claim_lines(path: Path, root: Path) -> None:
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    for index, line in enumerate(lines):
+        lower = line.lower()
+        for term in FORBIDDEN_CLAIM_TERMS:
+            term_index = lower.find(term.lower())
+            if term_index == -1:
+                continue
+            promotion_prefix = line[max(0, term_index - 80) : term_index]
+            if POSITIVE_PROMOTION_RE.search(promotion_prefix) and not ALLOWED_CLAIM_CONTEXT_RE.search(line):
+                fail(f"unbounded blocked claim term in {rel(path, root)}:{index + 1}: {term}")
+            context = " ".join(lines[max(0, index - 25) : index + 1])
+            if not ALLOWED_CLAIM_CONTEXT_RE.search(context):
+                fail(f"unbounded blocked claim term in {rel(path, root)}:{index + 1}: {term}")
+
+
 def scan_source_only_claims(package_dir: Path, root: Path) -> None:
-    text_files = [p for p in package_dir.rglob("*") if p.is_file() and p.suffix.lower() in {".md", ".yml", ".yaml", ".spl", ".xml", ".jsonpath"}]
+    text_files = [
+        p
+        for p in package_dir.rglob("*")
+        if p.is_file() and p.suffix.lower() in {".md", ".yml", ".yaml", ".spl", ".xml", ".jsonpath"}
+    ]
     for path in text_files:
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-        for index, line in enumerate(lines):
-            lower = line.lower()
-            for term in FORBIDDEN_CLAIM_TERMS:
-                if term.lower() not in lower:
-                    continue
-                context = " ".join(lines[max(0, index - 25) : index + 1])
-                if not ALLOWED_CLAIM_CONTEXT_RE.search(context):
-                    fail(f"unbounded blocked claim term in {rel(path, root)}:{index + 1}: {term}")
+        scan_claim_lines(path, root)
+
+
+def scan_global_metadata_claims(root: Path) -> None:
+    for relative_path in (MATRIX_PATH.relative_to(ROOT), INDEX_PATH.relative_to(ROOT)):
+        path = root / relative_path
+        if not path.exists():
+            fail(f"missing global metadata file: {relative_path.as_posix()}")
+        scan_claim_lines(path, root)
 
 
 def verify_entry(entry: dict[str, Any], root: Path) -> tuple[str, str]:
@@ -282,6 +331,76 @@ def verify_entry(entry: dict[str, Any], root: Path) -> tuple[str, str]:
     return detection_id, package_path
 
 
+def verify_ledger_eligibility_map(matrix: dict[str, Any], detection_ids: set[str]) -> dict[str, str]:
+    configured_status_values = ensure_list(
+        matrix.get("ledger_eligibility_status_values"),
+        "matrix.ledger_eligibility_status_values",
+    )
+    if set(configured_status_values) != ALLOWED_LEDGER_ELIGIBILITY_STATUS:
+        fail("matrix.ledger_eligibility_status_values must match the allowed ledger eligibility statuses")
+
+    eligibility = ensure_mapping(
+        matrix.get("detection_side_ledger_eligibility"),
+        "matrix.detection_side_ledger_eligibility",
+    )
+    missing_buckets = sorted(set(LEDGER_ELIGIBILITY_BUCKETS) - set(eligibility))
+    if missing_buckets:
+        fail(f"matrix.detection_side_ledger_eligibility missing buckets: {', '.join(missing_buckets)}")
+    extra_buckets = sorted(set(eligibility) - set(LEDGER_ELIGIBILITY_BUCKETS))
+    if extra_buckets:
+        fail(f"matrix.detection_side_ledger_eligibility has unapproved buckets: {', '.join(extra_buckets)}")
+
+    id_to_status: dict[str, str] = {}
+    for bucket, status in LEDGER_ELIGIBILITY_BUCKETS.items():
+        values = ensure_list(eligibility[bucket], f"matrix.detection_side_ledger_eligibility.{bucket}")
+        for detection_id in values:
+            if not isinstance(detection_id, str) or not detection_id.strip():
+                fail(f"matrix.detection_side_ledger_eligibility.{bucket} must contain non-empty detection IDs")
+            detection_id = detection_id.strip()
+            if detection_id not in detection_ids:
+                fail(f"ledger eligibility references unknown detection_id: {detection_id}")
+            if detection_id in id_to_status:
+                fail(f"ledger eligibility classifies {detection_id} more than once")
+            id_to_status[detection_id] = status
+
+    missing_ids = sorted(detection_ids - set(id_to_status))
+    if missing_ids:
+        fail(f"ledger eligibility missing detection IDs: {', '.join(missing_ids)}")
+    return id_to_status
+
+
+def verify_reviewer_expansion_map(matrix: dict[str, Any], id_to_status: dict[str, str]) -> None:
+    reviewer_map = ensure_list(matrix.get("reviewer_expansion_map"), "matrix.reviewer_expansion_map")
+    seen: set[str] = set()
+    for raw_entry in reviewer_map:
+        entry = ensure_mapping(raw_entry, "reviewer expansion map entry")
+        missing = sorted(REVIEWER_EXPANSION_REQUIRED_FIELDS.difference(entry))
+        detection_id = entry.get("detection_id", "<unknown>")
+        if missing:
+            fail(f"reviewer expansion map entry {detection_id} missing required fields: {', '.join(missing)}")
+        if not isinstance(detection_id, str) or not detection_id.strip():
+            fail("reviewer expansion map detection_id must be a non-empty string")
+        detection_id = detection_id.strip()
+        if detection_id not in id_to_status:
+            fail(f"reviewer expansion map references unknown detection_id: {detection_id}")
+        if detection_id in seen:
+            fail(f"reviewer expansion map duplicates detection_id: {detection_id}")
+        seen.add(detection_id)
+        ledger_status = entry["ledger_eligibility_status"]
+        if ledger_status not in ALLOWED_LEDGER_ELIGIBILITY_STATUS:
+            fail(f"{detection_id} ledger_eligibility_status not allowed: {ledger_status}")
+        if ledger_status != id_to_status[detection_id]:
+            fail(f"{detection_id} ledger_eligibility_status does not match bucketed eligibility map")
+        for field in ("reviewer_lane", "reviewer_summary", "next_reviewer_action"):
+            value = entry[field]
+            if not isinstance(value, str) or not value.strip():
+                fail(f"{detection_id}.{field} must be a non-empty string")
+
+    missing_ids = sorted(set(id_to_status) - seen)
+    if missing_ids:
+        fail(f"reviewer expansion map missing detection IDs: {', '.join(missing_ids)}")
+
+
 def verify_repo(root: Path = ROOT, print_summary: bool = True) -> list[dict[str, Any]]:
     matrix_path = root / MATRIX_PATH.relative_to(ROOT)
     if not matrix_path.exists():
@@ -300,6 +419,10 @@ def verify_repo(root: Path = ROOT, print_summary: bool = True) -> list[dict[str,
             fail(f"duplicate detection_id in matrix: {detection_id}")
         seen[detection_id] = package_path
         normalized_entries.append(copy.deepcopy(entry))
+
+    id_to_status = verify_ledger_eligibility_map(matrix, set(seen))
+    verify_reviewer_expansion_map(matrix, id_to_status)
+    scan_global_metadata_claims(root)
 
     packages = package_ids(root)
     missing_from_matrix = sorted(set(packages) - set(seen))

--- a/tests/test_verify_detection_promotion_matrix.py
+++ b/tests/test_verify_detection_promotion_matrix.py
@@ -73,6 +73,37 @@ class PromotionMatrixVerifierTests(unittest.TestCase):
                     matrix.verify_repo(self.root, print_summary=False)
                 self.write_matrix(self.load_matrix_from_repo())
 
+    def test_invalid_ledger_eligibility_status_fails(self):
+        data = self.load_matrix()
+        data["reviewer_expansion_map"][0]["ledger_eligibility_status"] = "PUBLIC_PROOF_READY"
+        self.write_matrix(data)
+        with self.assertRaises(matrix.MatrixError):
+            matrix.verify_repo(self.root, print_summary=False)
+
+    def test_missing_reviewer_expansion_map_field_fails(self):
+        data = self.load_matrix()
+        data["reviewer_expansion_map"][0].pop("next_reviewer_action")
+        self.write_matrix(data)
+        with self.assertRaises(matrix.MatrixError):
+            matrix.verify_repo(self.root, print_summary=False)
+
+    def test_extra_ledger_eligibility_bucket_fails(self):
+        data = self.load_matrix()
+        data["detection_side_ledger_eligibility"]["public_proof_ready"] = []
+        self.write_matrix(data)
+        with self.assertRaises(matrix.MatrixError):
+            matrix.verify_repo(self.root, print_summary=False)
+
+    def test_unbounded_factory_index_claim_fails(self):
+        index_path = self.root / "detections" / "DETECTION_FACTORY_INDEX.md"
+        index_path.write_text(
+            index_path.read_text(encoding="utf-8")
+            + "\n\nHO-DET-001 now has public-safe proof.\n",
+            encoding="utf-8",
+        )
+        with self.assertRaises(matrix.MatrixError):
+            matrix.verify_repo(self.root, print_summary=False)
+
     def test_package_tree_missing_from_matrix_fails(self):
         data = self.load_matrix()
         data["entries"] = [item for item in data["entries"] if item["detection_id"] != "HO-DET-013"]


### PR DESCRIPTION
## Summary

- Adds detection-side ledger eligibility buckets to `DETECTION_PROMOTION_MATRIX.yml`.
- Adds reviewer-readable eligibility routing to `DETECTION_FACTORY_INDEX.md`.
- Hardens `verify_detection_promotion_matrix.py` to enforce approved bucket maps, reviewer expansion fields, and bounded wording.
- Expands tests for invalid statuses, missing fields, extra bucket drift, and unbounded factory-index wording.

## Validation

- `python -B scripts/verify_detection_promotion_matrix.py`
- `python -B tests/test_verify_detection_promotion_matrix.py`
- `python -B scripts/verify_detection_contract.py`
- `git diff --check`

## Boundary statement

- `hawkinsoperations-detections` owns source-side eligibility/readiness metadata only.
- `hawkinsoperations-platform` owns canonical Lifetime Case Ledger append truth.
- This PR does not append ledger entries.
- This PR does not edit detection logic.
- This PR does not change runtime, signal, proof, publication, operating-environment, or approval-authority status.

## Reviewer value

- Makes the detections repo easier to scan.
- Shows which detections are proof-recorded, dry-run ready, validation ready, blocked, future candidates, or need telemetry contracts.
- Supports the larger HawkinsOperations goal of making the GitHub organization self-explanatory to reviewers without collapsing authority boundaries.