### PR TITLE
docs(readme): align reviewer value and authority boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,88 @@
 # HawkinsOperations Detections
 
-Detection content and rule engineering for HawkinsOperations.
+This repo is the HawkinsOperations detection source-truth layer: it shows how detection ideas become source-controlled rules, reviewer-readable metadata, and promotion candidates without pretending source code is runtime proof.
 
-Owner identity: Raylee Hawkins, Detection Engineer | SOC Automation | Detection-as-Code | Security Automation.
+## What A Reviewer Should See In 10 Seconds
 
-Official links: [Raylee Hawkins on LinkedIn](https://www.linkedin.com/in/raylee-hawkins) | [Raylee Hawkins on GitHub](https://github.com/raylee-hawkins) | [HawkinsOps legacy/reference portfolio](https://hawkinsops.com) | [HawkinsOperations GitHub organization](https://github.com/HawkinsOperations) | [RayleeOps public operating journal](https://rayleeops.com)
+- **Purpose:** detection engineering source, not runtime operations.
+- **Value:** clear detection logic, field mapping, blocked claims, and promotion gates a reviewer can inspect.
+- **Path:** source here -> deterministic validation in `hawkinsoperations-validation` -> bounded proof records in `hawkinsoperations-proof`.
+- **Boundary:** this repo does not prove deployed coverage, live signals, production triage, public-safe proof, SOCaaS availability, or AI final disposition.
 
-## Purpose
+## Source To Validation To Proof
 
-This repository contains detection logic as source content. It is the authoring layer for promotion-bound security detections; source presence does not prove runtime activity, signal observation, or production deployment.
+| Step | Where it lives | What it can show | What it cannot show |
+|---|---|---|---|
+| Source | `hawkinsoperations-detections` | Detection rules, SPL/Sigma/Wazuh sources, event mappings, metadata, blocked claims, and next gates | Runtime execution, signal observation, production deployment, public-safe proof, or final disposition |
+| Validation | `hawkinsoperations-validation` | Deterministic fixture or contract results within the stated test scope | Live telemetry, production quality, public-safe proof, or analyst approval |
+| Proof | `hawkinsoperations-proof` | Bounded proof records and reviewer routes after the required review gates | Broader claims than the approved record, current runtime state, or reusable public-safe status by default |
 
-## HawkinsOperations Closed SOC Loop 001
+## Detection Reviewer Route
 
-- GitHub Projects: pending access / attachment. Current org project route: https://github.com/orgs/HawkinsOperations/projects
-- Reviewer entry point: https://github.com/HawkinsOperations/.github/blob/main/profile/START_HERE.md
-- HO-DET-001 public proof route: https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/HO-DET-001.md
-- Current HO-DET-001 ceiling: CONTROLLED_TEST_VALIDATED
-- HawkinsOperations is the governed successor system; HawkinsOps and older surfaces are legacy/reference unless revalidated.
-- Truth surface: detection source truth. This repository proves source existence and detection-authoring structure only.
-- Sprint thesis: speed with enforcement through deterministic validation, required checks where configured, evidence records, proof contracts, and bounded public claims.
-- AI is labor. Governance is authority.
-- Build loud. Verify hard. Claim tight. Ship receipts.
-- Website/public pages route to proof records; they do not replace proof.
-- Next gates: case packet spine, deterministic verifier, claim-boundary scanner, CI proof-loop, proof card, website route.
-- Cyber Kill Chain coverage: this repo contributes detection source truth to the canonical [Cyber Kill Chain coverage map](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/docs/mappings/CYBER_KILL_CHAIN_COVERAGE.md) in `hawkinsoperations-proof`. The map is reviewer navigation, not runtime, signal, production, or public-safe proof authority.
+Start with the factory view, then follow the candidate-specific source and proof routes:
+
+- Factory matrix: [`detections/DETECTION_FACTORY_INDEX.md`](detections/DETECTION_FACTORY_INDEX.md)
+- Promotion metadata: [`detections/DETECTION_PROMOTION_MATRIX.yml`](detections/DETECTION_PROMOTION_MATRIX.yml)
+- Scope boundary: [`SCOPE.md`](SCOPE.md)
+- Organization reviewer start: [`HawkinsOperations/.github profile`](https://github.com/HawkinsOperations/.github/blob/main/profile/START_HERE.md)
+- Proof record route: [`hawkinsoperations-proof/proof/records`](https://github.com/HawkinsOperations/hawkinsoperations-proof/tree/main/proof/records)
+
+## HO-DET-001 Source Route
+
+HO-DET-001 is included here only because it already exists in this repository as a source package and reviewer route. The proof ceiling is controlled by the proof record, not by this README.
+
+| Source item | Route |
+|---|---|
+| Sigma source | [`detections/successor/ho-det-001/rule.yml`](detections/successor/ho-det-001/rule.yml) |
+| Splunk source | [`detections/successor/ho-det-001/splunk.spl`](detections/successor/ho-det-001/splunk.spl) |
+| Event mapping | [`detections/successor/ho-det-001/event-mapping.yml`](detections/successor/ho-det-001/event-mapping.yml) |
+| Source status metadata | [`detections/successor/ho-det-001/status.yml`](detections/successor/ho-det-001/status.yml) |
+| Reviewer proof route | [`HO-DET-001 proof record`](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/HO-DET-001.md) |
+
+Safe reading: this repo can show source existence and authoring structure for HO-DET-001. Validation and proof claims must be read from their owning repositories and bounded by their current records.
+
+## Repository Authority
+
+This repository owns:
+
+- Detection source files.
+- Detection metadata and taxonomy.
+- Source-side event mappings.
+- Source-side promotion readiness metadata.
+- Build or conversion logic for detection artifacts.
+
+This repository does not own:
+
+- Validation execution results.
+- Runtime platform state.
+- Signal observation.
+- Public proof approval.
+- Website/public narrative authority.
+- Human or AI final disposition.
 
 ## Blocked Claims
 
-This repository does not claim: runtime-active, signal-observed, evidence-linked public proof, public-safe, live Splunk firing, production triage, analyst-approved disposition, HO-GPU-01 runtime-active, Cribl-routed, Wazuh-routed, AWS-live, autonomous SOC, production-ready SOC, fleet-wide deployment, or AI-approved disposition.
+Do not cite this repo as evidence for:
 
-## Scope
+- runtime-active status
+- signal-observed status
+- evidence-linked public proof
+- public-safe status
+- live Splunk firing
+- Wazuh-routed proof
+- Cribl-routed proof
+- AWS-live proof
+- production triage
+- production-ready SOC
+- fleet-wide deployment
+- SOCaaS availability
+- autonomous SOC operation
+- analyst-approved disposition
+- AI-approved disposition
+- AI-decided disposition
 
-- Detection rules (Sigma/Wazuh/Splunk-compatible sources)
-- Detection metadata and taxonomy
-- Build/conversion scripts for detection artifacts
+## Hiring Signal
 
-## Out of Scope
+For a reviewer, the value here is not a claim that HawkinsOperations is operating as a live service. The value is a disciplined detection-engineering system: source-controlled rules, explicit truth boundaries, deterministic validation routes, proof-record handoff, and blocked-claim hygiene.
 
-- Runtime platform deployment state, which belongs to the internal platform route and is not source proof
-- Host-specific operational logs
-- Internal-only credentials, endpoints, or infrastructure secrets
-
-## Repository Contract
-
-- Source-of-truth detection content lives here.
-- Generated artifacts are reproducible from source.
-- Changes must be explainable with validation evidence from `hawkinsoperations-validation`.
-
-## Reviewed External Proof Candidates
-
-- Sanitized detection examples
-- Rule quality checks
-- Change history with rationale
-
-## Hero Detections
-
-- `001-powershell-encoded-command`  
-  Path: `detections/hero/001-powershell-encoded-command/`
-
-## Related Repositories
-
-- Validation: `hawkinsoperations-validation`
-- Platform/runtime contracts: internal platform route, not source proof
-- Proof: `hawkinsoperations-proof`
-- Website: `hawkinsoperations-website`
+AI is labor. Governance is authority.


### PR DESCRIPTION
## Summary
- Reframes the README as detection source truth for reviewers.
- Adds a fast reviewer path and source -> validation -> proof flow.
- Keeps HO-DET-001 bounded as source/reviewer routing, not runtime or signal proof.

## README stress tests run
- 10-second hook: PASS
- So-What test: PASS
- Jargon translation: PASS
- Proof boundary: PASS
- Reviewer path: PASS
- Executive billboard: PASS
- Visual structure: PASS
- Repo authority: PASS
- Hiring signal: PASS
- Final diff scope: PASS

## Scope
- README.md only.
- No validation repo edits.
- No workflows, source code, schemas, validators, proof records, website source/data, non-README docs, issues, projects, settings, branch protection, or release assets changed.

## Proof boundary
This PR does not promote public-safe status, runtime-active status, signal-observed status, production/SOCaaS availability, proof ceiling, analyst disposition, or AI authority.

## Reviewer value
The README now puts reviewer value before internal mechanics and keeps repo authority boundaries explicit.

## Validation
- README.md only changed.
- git diff --check -- README.md passed.
- Parent scope scan confirmed only README.md changed.
- Private path scan passed.
- Proof-boundary scan found restricted terms only in blocked/boundary language.

## Exclusion note
hawkinsoperations-validation was intentionally excluded from this sprint because it has existing unrelated non-README work on eature/runtime-proof-runner-trust-split-v1.