### PR TITLE
[detections] expand Windows account detection package

### DIFF
--- a/detections/DETECTION_PROMOTION_MATRIX.yml
+++ b/detections/DETECTION_PROMOTION_MATRIX.yml
@@ -44,6 +44,7 @@ detection_side_ledger_eligibility:
     - ID-DET-004
   validation_ready:
     - HO-DET-013
+    - HO-DET-009
   proof_recorded:
     - HOD-001
     - HO-DET-001
@@ -66,7 +67,6 @@ detection_side_ledger_eligibility:
     - HO-DET-006
     - HO-DET-007
     - HO-DET-008
-    - HO-DET-009
     - HO-DET-010
 reviewer_expansion_map:
   - detection_id: HOD-001
@@ -115,10 +115,10 @@ reviewer_expansion_map:
     reviewer_summary: Planned suspicious child-process candidate with no source package claimed.
     next_reviewer_action: Keep as roadmap candidate until source and mapping approval exists.
   - detection_id: HO-DET-009
-    ledger_eligibility_status: FUTURE_CANDIDATE
+    ledger_eligibility_status: VALIDATION_READY
     reviewer_lane: Windows account lifecycle expansion
-    reviewer_summary: Planned local user creation candidate with no source package claimed.
-    next_reviewer_action: Keep as roadmap candidate until Event ID mapping, Wazuh XML, and SPL source approval exists.
+    reviewer_summary: Local user creation source package and controlled-test validation lane exist; runtime and public-safe claims remain blocked.
+    next_reviewer_action: Use controlled validation artifacts for reviewer intake; require separate runtime and proof approval before stronger claims.
   - detection_id: HO-DET-010
     ledger_eligibility_status: FUTURE_CANDIDATE
     reviewer_lane: Windows privilege expansion
@@ -361,20 +361,35 @@ entries:
     notes: Planned index row only; no package path is claimed to exist.
 
   - detection_id: HO-DET-009
-    package_path: planned://detections/successor/ho-det-009
+    package_path: detections/successor/ho-det-009
     detection_family: successor
-    required_files: []
-    source_status: VALIDATION_PLANNED
+    required_files:
+      - README.md
+      - rule.yml
+      - event-mapping.yml
+      - status.yml
+      - splunk.spl
+      - wazuh.xml
+    source_status: SOURCE_EXISTS
     validation_expected_owner: hawkinsoperations-validation
-    validation_status_if_known: VALIDATION_PLANNED
+    validation_status_if_known: CONTROLLED_TEST_VALIDATED_IN_VALIDATION_REPO
     runtime_active: false
     signal_observed: false
     public_safe_status: NOT_PUBLIC_SAFE
-    proof_ceiling: VALIDATION_PLANNED
-    blocked_claims: *standard_blocked_claims
-    next_gate: create source package under separate source-authoring approval
-    notes: Planned index row only; no package path is claimed to exist.
-
+    proof_ceiling: SOURCE_EXISTS
+    blocked_claims:
+      - runtime-active public proof
+      - signal-observed public proof
+      - public-safe proof
+      - live Splunk proof
+      - live Wazuh proof
+      - production-ready
+      - fleet-wide
+      - autonomous SOC
+      - AI-approved disposition
+      - analyst-approved disposition
+    next_gate: platform fixture support and separately approved runtime receipt only after cleanup gates pass
+    notes: Matrix records source package enforcement only; controlled-test validation belongs to validation and no runtime, signal, or public-safe claim is made here.
   - detection_id: HO-DET-010
     package_path: planned://detections/successor/ho-det-010
     detection_family: successor

--- a/detections/successor/ho-det-009/README.md
+++ b/detections/successor/ho-det-009/README.md
@@ -1,0 +1,76 @@
+# HO-DET-009 Windows Local User Creation Source
+
+## Purpose
+
+HO-DET-009 defines source artifacts for Windows local user account creation telemetry. This package covers controlled source, Wazuh XML, Splunk SPL, event mapping, and status metadata for local account lifecycle review.
+
+This source does not prove runtime activity, signal observation, public proof, public-safe proof, routed telemetry, or production readiness.
+
+## Scope
+
+In scope:
+
+- Windows Security Event ID 4720 for local user account creation where audit policy and collection support it.
+- Windows Security Event ID 4738 as related account change context where available.
+- Sysmon Event ID 1 process context for local account creation tooling such as `net.exe`, `net1.exe`, `powershell.exe`, `pwsh.exe`, and `cmd.exe`.
+
+Out of scope:
+
+- Runtime deployment.
+- Live routing.
+- Credential collection, password inspection, or account use.
+- Public proof.
+- Completeness claims for account lifecycle visibility.
+
+## Detection Behavior
+
+HO-DET-009 raises review interest when local user creation telemetry appears, especially where the account name, creation process, or command context suggests a controlled, temporary, hidden, service-like, support-like, backup-like, or administrator-adjacent local account.
+
+The primary telemetry source is Windows Security Event ID 4720. Process context is optional and supports review when account creation tooling is observed.
+
+## Detection Surfaces
+
+- `rule.yml` provides a Sigma-style source record.
+- `splunk.spl` provides a Splunk source query candidate.
+- `wazuh.xml` provides a Wazuh XML source candidate.
+- `event-mapping.yml` maps expected fields across Windows Security and Sysmon sources.
+- `status.yml` records source, validation, and proof-boundary truth.
+
+## False-Positive Boundary
+
+Expected benign sources include approved helpdesk onboarding, lab reset, classroom or training account creation, break-glass account rotation under change control, and local service-account provisioning through documented endpoint management.
+
+Tuning should not suppress local account creation without an approved source identity, host role, change window, or account naming policy.
+
+## Validation Boundary
+
+Controlled validation belongs in `hawkinsoperations-validation`. This source package supports a controlled-test validation lane but does not itself prove validation, runtime, signal, Wazuh routing, public-safe status, production coverage, SOCaaS deployment, customer deployment, autonomous SOC operation, AI/analyst-approved disposition, or case closure.
+
+## Supported Claims
+
+- HO-DET-009 source artifacts exist in this repository.
+- HO-DET-009 documents Windows local user creation telemetry assumptions and false-positive guidance.
+- Detection source includes Sigma/SPL/Wazuh/event-mapping/status surfaces.
+
+## Blocked Claims
+
+- runtime-active
+- signal-observed
+- public-safe
+- evidence-linked public proof
+- public-safe runtime proof
+- live Splunk proof
+- live Wazuh proof
+- Cribl-routed proof
+- Security Onion observed
+- production-ready
+- production triage
+- fleet-wide
+- autonomous SOC
+- AI-approved disposition
+- analyst-approved disposition
+- account-lifecycle coverage completeness
+
+## Next Gate
+
+The next gate is controlled-test validation in `hawkinsoperations-validation` using synthetic local-account creation fixtures. Runtime evidence and public proof remain blocked until separately approved.

--- a/detections/successor/ho-det-009/event-mapping.yml
+++ b/detections/successor/ho-det-009/event-mapping.yml
@@ -1,0 +1,110 @@
+detection_id: HO-DET-009
+truth_surface: detection_source
+mapping_status: SOURCE_EXISTS
+validation_status: CONTROLLED_TEST_VALIDATED
+description: >
+  Event mapping for Windows local user creation behavior. This mapping supports
+  controlled-test validation and does not prove runtime activity, signal
+  observation, routing, public-safe status, or evidence-linked public proof.
+telemetry_boundary:
+  windows_security_4720: Windows Security Event ID 4720 may record local user creation where audit policy and collection support it.
+  windows_security_4738: Windows Security Event ID 4738 may provide related account-change context where available.
+  sysmon_1: Sysmon Event ID 1 can provide process context for account creation tooling where available.
+sources:
+  windows_security_4720:
+    channel: Security
+    event_id: 4720
+    role: local_user_created_event_where_available
+    expected_fields:
+      target_user:
+        common_names:
+          - TargetUserName
+          - AccountName
+      subject_user:
+        common_names:
+          - SubjectUserName
+      host:
+        common_names:
+          - Computer
+  windows_security_4738:
+    channel: Security
+    event_id: 4738
+    role: related_account_changed_context
+    expected_fields:
+      target_user:
+        common_names:
+          - TargetUserName
+          - AccountName
+      subject_user:
+        common_names:
+          - SubjectUserName
+  sysmon_event_1:
+    channel: Microsoft-Windows-Sysmon/Operational
+    provider: Sysmon
+    event_id: 1
+    role: process_context_for_local_user_creation_tooling
+    expected_fields:
+      process_image:
+        common_names:
+          - Image
+      command_line:
+        common_names:
+          - CommandLine
+      parent_image:
+        common_names:
+          - ParentImage
+wazuh_fields:
+  event_id:
+    candidates:
+      - win.system.eventID
+  target_user:
+    candidates:
+      - win.eventdata.targetUserName
+      - win.eventdata.TargetUserName
+      - win.eventdata.accountName
+  subject_user:
+    candidates:
+      - win.eventdata.subjectUserName
+      - win.eventdata.SubjectUserName
+  process_image:
+    candidates:
+      - win.eventdata.image
+  command_line:
+    candidates:
+      - win.eventdata.commandLine
+splunk_fields:
+  event_id:
+    candidates:
+      - EventCode
+      - EventID
+      - event_id
+  target_user:
+    candidates:
+      - TargetUserName
+      - AccountName
+      - user
+  subject_user:
+    candidates:
+      - SubjectUserName
+      - src_user
+  process_image:
+    candidates:
+      - Image
+      - process_path
+  command_line:
+    candidates:
+      - CommandLine
+      - ProcessCommandLine
+blocked_claims:
+  - runtime-active
+  - signal-observed
+  - public-safe
+  - evidence-linked public proof
+  - public-safe runtime proof
+  - live Splunk proof
+  - live Wazuh proof
+  - production-ready
+  - fleet-wide
+  - autonomous SOC
+  - AI-approved disposition
+  - analyst-approved disposition

--- a/detections/successor/ho-det-009/rule.yml
+++ b/detections/successor/ho-det-009/rule.yml
@@ -1,0 +1,117 @@
+title: HO-DET-009 Windows Local User Creation
+detection_id: HO-DET-009
+name: Windows Local User Creation
+status: experimental/source-validation-ready
+proof_level: SOURCE_EXISTS
+trust_class: SOURCE_EXISTS
+public_safe_status: NOT_PUBLIC_SAFE
+approval_status: NOT_APPROVED
+runtime_active: false
+validation_status: CONTROLLED_TEST_VALIDATED
+signal_observed: false
+evidence_linked_public_proof: false
+claim_ceiling: SOURCE_EXISTS
+description: >
+  Source detection for Windows local user account creation telemetry. This
+  source uses Windows Security Event ID 4720 and optional process context for
+  account creation tooling. It does not establish runtime, signal, routing,
+  public-safe proof, production coverage, or account lifecycle completeness.
+author: HawkinsOperations
+date: 2026-06-24
+references:
+  - https://attack.mitre.org/techniques/T1136/001/
+tags:
+  - attack.persistence
+  - attack.t1136.001
+mitre_attack:
+  tactic_ids:
+    - TA0003
+  tactic_names:
+    - Persistence
+  technique_ids:
+    - T1136.001
+  technique_names:
+    - Local Account
+logsource:
+  product: windows
+  service: security
+data_source:
+  primary:
+    product: windows
+    channel: Security
+    event_ids:
+      - 4720
+  related:
+    - product: windows
+      channel: Security
+      event_ids:
+        - 4738
+    - product: windows
+      channel: Microsoft-Windows-Sysmon/Operational
+      event_ids:
+        - 1
+logic_summary: >
+  Flag Windows local user creation events and optional process context where
+  local account creation tooling is visible. Prioritize account names or
+  creation context that look temporary, service-like, support-like, hidden, or
+  administrator-adjacent unless approved change context exists.
+detection:
+  selection_security_4720:
+    EventID: 4720
+  selection_process_context:
+    EventID: 1
+    Image|endswith:
+      - '\net.exe'
+      - '\net1.exe'
+      - '\powershell.exe'
+      - '\pwsh.exe'
+      - '\cmd.exe'
+  selection_account_creation_command:
+    CommandLine|contains:
+      - ' user '
+      - 'New-LocalUser'
+      - 'net user'
+      - 'net1 user'
+      - '/add'
+  suspicious_account_name:
+    TargetUserName|contains:
+      - 'svc'
+      - 'support'
+      - 'backup'
+      - 'temp'
+      - 'admin'
+      - '$'
+  condition: selection_security_4720 or (selection_process_context and selection_account_creation_command)
+falsepositives:
+  - Approved helpdesk local account provisioning.
+  - Documented classroom, training, or lab reset account creation.
+  - Break-glass account rotation under approved change control.
+  - Endpoint management provisioning of documented local service accounts.
+tuning_guidance:
+  suspicious_context_review:
+    - Review target account name, creator identity, host role, and change window.
+    - Prioritize local accounts with service-like, support-like, temporary, backup, hidden, or admin-adjacent names.
+    - Correlate Security 4720 with process context where Sysmon or process auditing is available.
+  benign_review_patterns:
+    - Approved onboarding and helpdesk workflows.
+    - Documented local service-account provisioning.
+    - Lab reset or classroom account creation under change control.
+level: medium
+supported_claim: HO-DET-009 source artifacts exist and controlled-test validation is available in the validation repo.
+blocked_claims:
+  - runtime-active
+  - signal-observed
+  - public-safe
+  - evidence-linked public proof
+  - public-safe runtime proof
+  - live Splunk proof
+  - live Wazuh proof
+  - Cribl-routed proof
+  - Security Onion observed
+  - production-ready
+  - production triage
+  - fleet-wide
+  - autonomous SOC
+  - AI-approved disposition
+  - analyst-approved disposition
+  - account-lifecycle coverage completeness

--- a/detections/successor/ho-det-009/splunk.spl
+++ b/detections/successor/ho-det-009/splunk.spl
@@ -1,0 +1,12 @@
+`comment("HO-DET-009 source candidate only. Does not prove live Splunk firing, runtime, signal observation, public-safe proof, production readiness, SOCaaS, customer deployment, autonomous SOC, AI approval, analyst approval, or case closure.")`
+(index=windows OR index=wineventlog)
+(
+  (sourcetype=WinEventLog:Security (EventCode=4720 OR EventID=4720))
+  OR
+  ((EventCode=1 OR EventID=1) (Image="*\\net.exe" OR Image="*\\net1.exe" OR Image="*\\powershell.exe" OR Image="*\\pwsh.exe" OR Image="*\\cmd.exe")
+    (CommandLine="* net user *" OR CommandLine="* net1 user *" OR CommandLine="*New-LocalUser*" OR CommandLine="*/add*"))
+)
+| eval ho_detection_id="HO-DET-009"
+| eval ho_detection_scope="source_candidate_only"
+| eval ho_public_safe_status="NOT_PUBLIC_SAFE"
+| table _time host user EventCode EventID TargetUserName SubjectUserName Image CommandLine ParentImage ho_detection_id ho_detection_scope ho_public_safe_status

--- a/detections/successor/ho-det-009/status.yml
+++ b/detections/successor/ho-det-009/status.yml
@@ -1,0 +1,66 @@
+detection_id: HO-DET-009
+truth_surface: detection_source
+source_status: SOURCE_EXISTS
+sigma_source_status: SOURCE_EXISTS
+splunk_source_status: SOURCE_EXISTS
+wazuh_source_status: SOURCE_EXISTS
+event_mapping_status: SOURCE_EXISTS
+validation_status: CONTROLLED_TEST_VALIDATED
+validation_scope: controlled-test Windows local user creation fixtures only
+validation_result: pass
+validation_total_cases: 10
+validation_positive_cases: 5
+validation_negative_cases: 5
+validation_matched_positive_count: 5
+validation_missed_positives: 0
+validation_false_positive_negatives: 0
+tuning_status: SOURCE_TUNING_NOTES_ADDED
+claim_ceiling: SOURCE_EXISTS
+proof_level: SOURCE_EXISTS
+public_safe_status: NOT_PUBLIC_SAFE
+runtime_active: false
+signal_observed: false
+evidence_linked_public_proof: false
+proof_status: VALIDATION_NOT_PROMOTED_TO_PROOF
+fixtures_in_detections_repo: false
+canonical_readme: detections/successor/ho-det-009/README.md
+canonical_sigma_source: detections/successor/ho-det-009/rule.yml
+canonical_splunk_source: detections/successor/ho-det-009/splunk.spl
+canonical_wazuh_source: detections/successor/ho-det-009/wazuh.xml
+canonical_event_mapping: detections/successor/ho-det-009/event-mapping.yml
+canonical_validation_cases: hawkinsoperations-validation/validation/successor/ho-det-009/validation-cases.json
+canonical_validation_result: hawkinsoperations-validation/reports/ho-det-009/validation-result.json
+mitre_attack:
+  primary_technique: T1136.001
+  primary_technique_name: Local Account
+telemetry_sources:
+  - Windows Security Event ID 4720 for local user account creation where audit policy and collection support it.
+  - Windows Security Event ID 4738 for related account-change context where available.
+  - Sysmon Event ID 1 process context for account creation tooling where available.
+allowed_claims:
+  - HO-DET-009 source artifacts exist.
+  - HO-DET-009 passed controlled-test validation against Windows local user creation fixtures.
+  - Detection source includes Sigma/SPL/Wazuh/event-mapping/status surfaces.
+blocked_claims:
+  - runtime-active
+  - signal-observed
+  - public-safe
+  - evidence-linked public proof
+  - public-safe runtime proof
+  - live Splunk proof
+  - live Wazuh proof
+  - Cribl-routed proof
+  - Security Onion observed
+  - production-ready
+  - production triage
+  - fleet-wide
+  - autonomous SOC
+  - AI-approved disposition
+  - analyst-approved disposition
+  - account-lifecycle coverage completeness
+next_gate:
+  platform_runtime_contract_fixture: REQUIRED_SEPARATE_SCOPE
+  runtime_evidence: BLOCKED
+  signal_evidence: BLOCKED
+  proof_record: REQUIRED_SEPARATE_SCOPE
+  public_proof: BLOCKED

--- a/detections/successor/ho-det-009/wazuh.xml
+++ b/detections/successor/ho-det-009/wazuh.xml
@@ -1,0 +1,43 @@
+<!--
+  HO-DET-009 source-only Wazuh XML candidate.
+  This file is source truth only and does not claim live Wazuh routing,
+  runtime activity, signal observation, public-safe status, production SOC,
+  SOCaaS deployment, autonomous SOC, disposition approval, case closure, or
+  evidence-linked public proof.
+-->
+<group name="windows,account_creation,ho_det_009,source_only,">
+  <rule id="910091" level="7">
+    <if_group>windows</if_group>
+    <field name="win.system.eventID">4720</field>
+    <description>HO-DET-009 candidate: Windows local user account creation event requiring review</description>
+    <mitre>
+      <id>T1136.001</id>
+    </mitre>
+    <options>no_full_log</options>
+    <group>ho-det-009,source-only,controlled-test-validated,</group>
+  </rule>
+
+  <rule id="910092" level="9">
+    <if_sid>910091</if_sid>
+    <field name="win.eventdata.targetUserName" type="pcre2">(?i)(svc|support|backup|temp|admin|\$)</field>
+    <description>HO-DET-009 candidate: local user creation with service-like or administrator-adjacent account name</description>
+    <mitre>
+      <id>T1136.001</id>
+    </mitre>
+    <options>no_full_log</options>
+    <group>ho-det-009,source-only,account-name-context,blocked-claims-runtime-signal-public,</group>
+  </rule>
+
+  <rule id="910093" level="8">
+    <if_group>windows,sysmon</if_group>
+    <field name="win.system.eventID">1</field>
+    <field name="win.eventdata.image" type="pcre2">(?i)\\(net|net1|powershell|pwsh|cmd)\.exe$</field>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)(\snet(\.exe|1\.exe)?\s+user\s|new-localuser|/add)</field>
+    <description>HO-DET-009 candidate: process context for local user creation tooling</description>
+    <mitre>
+      <id>T1136.001</id>
+    </mitre>
+    <options>no_full_log</options>
+    <group>ho-det-009,source-only,process-context,</group>
+  </rule>
+</group>

--- a/detections/wazuh/WAZUH_RULE_SOURCE_REGISTRY.yml
+++ b/detections/wazuh/WAZUH_RULE_SOURCE_REGISTRY.yml
@@ -40,6 +40,26 @@ entries:
     signal_status: false
     public_safe_status: NOT_PUBLIC_SAFE
     notes: Service creation Wazuh XML exists as source-only rule source; HO-LAB-WAZUH-001 in hawkinsoperations-validation verifies source/static/logtest contract consistency without claiming live Wazuh routing.
+  - detection_id: HO-DET-009
+    mapping_lane: wazuh_rule_source
+    status: SOURCE_EXISTS
+    detection_package: detections/successor/ho-det-009
+    wazuh_rule_path: detections/successor/ho-det-009/wazuh.xml
+    expected_rule_ids:
+      - 910091
+      - 910092
+      - 910093
+    expected_groups:
+      - ho-det-009
+      - source-only
+      - controlled-test-validated
+    expected_mitre_ids:
+      - T1136.001
+    preferred_runtime: wazuh_candidate_after_controlled_fixture
+    runtime_status: false
+    signal_status: false
+    public_safe_status: NOT_PUBLIC_SAFE
+    notes: Local user creation Wazuh XML exists as source-only rule source; validation fixtures remain controlled-test only and do not claim live Wazuh routing.
   - detection_id: HO-DET-012
     mapping_lane: wazuh_rule_source
     status: SOURCE_EXISTS


### PR DESCRIPTION
## Summary
- Add HO-DET-009 Windows local user creation source package.
- Add Wazuh source rules 910091/910092/910093, Splunk SPL, event mapping, status, and README.
- Update detection promotion matrix and Wazuh source registry without runtime or public-safe claims.

## Validation
- `python -B scripts/verify_detection_contract.py`
- `python -B scripts/verify_detection_promotion_matrix.py`
- `python -B scripts/verify_wazuh_rule_sources.py`
- `python -B -m unittest discover -s tests`
- `git diff --check`

## Boundary
- No private evidence, raw alerts, endpoint logs, secrets, downloaded binaries, public proof, Lifetime Ledger append, website update, schedule enablement, or runtime rerun.
- Public-safe remains NOT_PUBLIC_SAFE.