### PR TITLE
[detections] add HO-DET-010 local admins source package

### DIFF
--- a/detections/DETECTION_PROMOTION_MATRIX.yml
+++ b/detections/DETECTION_PROMOTION_MATRIX.yml
@@ -45,6 +45,7 @@ detection_side_ledger_eligibility:
   validation_ready:
     - HO-DET-013
     - HO-DET-009
+    - HO-DET-010
   proof_recorded:
     - HOD-001
     - HO-DET-001
@@ -67,7 +68,7 @@ detection_side_ledger_eligibility:
     - HO-DET-006
     - HO-DET-007
     - HO-DET-008
-    - HO-DET-010
+
 reviewer_expansion_map:
   - detection_id: HOD-001
     ledger_eligibility_status: PROOF_RECORDED
@@ -120,10 +121,10 @@ reviewer_expansion_map:
     reviewer_summary: Local user creation source package and controlled-test validation lane exist; runtime and public-safe claims remain blocked.
     next_reviewer_action: Use controlled validation artifacts for reviewer intake; require separate runtime and proof approval before stronger claims.
   - detection_id: HO-DET-010
-    ledger_eligibility_status: FUTURE_CANDIDATE
+    ledger_eligibility_status: VALIDATION_READY
     reviewer_lane: Windows privilege expansion
-    reviewer_summary: Planned local administrators group change candidate with no source package claimed.
-    next_reviewer_action: Keep as roadmap candidate until Event ID mapping, Wazuh XML, and SPL source approval exists.
+    reviewer_summary: Source and controlled-test validation are ready for Windows local Administrators group membership changes; no runtime or public-safe claim is made.
+    next_reviewer_action: Review source and validation artifacts before any separately approved VM108 runtime gate.
   - detection_id: HO-DET-011
     ledger_eligibility_status: PROOF_RECORDED
     reviewer_lane: Windows service persistence
@@ -391,19 +392,37 @@ entries:
     next_gate: platform fixture support and separately approved runtime receipt only after cleanup gates pass
     notes: Matrix records source package enforcement only; controlled-test validation belongs to validation and no runtime, signal, or public-safe claim is made here.
   - detection_id: HO-DET-010
-    package_path: planned://detections/successor/ho-det-010
+    package_path: detections/successor/ho-det-010
     detection_family: successor
-    required_files: []
-    source_status: VALIDATION_PLANNED
+    required_files:
+      - README.md
+      - rule.yml
+      - event-mapping.yml
+      - status.yml
+      - splunk.spl
+      - wazuh.xml
+    source_status: SOURCE_EXISTS
     validation_expected_owner: hawkinsoperations-validation
-    validation_status_if_known: VALIDATION_PLANNED
+    validation_status_if_known: CONTROLLED_TEST_VALIDATED_IN_VALIDATION_REPO
     runtime_active: false
     signal_observed: false
     public_safe_status: NOT_PUBLIC_SAFE
-    proof_ceiling: VALIDATION_PLANNED
-    blocked_claims: *standard_blocked_claims
-    next_gate: create source package under separate source-authoring approval
-    notes: Planned index row only; no package path is claimed to exist.
+    proof_ceiling: SOURCE_EXISTS
+    blocked_claims:
+      - runtime-active public proof
+      - signal-observed public proof
+      - public-safe proof
+      - live Splunk proof
+      - live Wazuh proof
+      - live Cribl proof
+      - live Security Onion proof
+      - production-ready
+      - fleet-wide
+      - autonomous SOC
+      - AI-approved disposition
+      - analyst-approved disposition
+    next_gate: reviewer validates source and controlled-test validation before any private runtime gate
+    notes: Source package exists for Windows local Administrators group membership changes. Runtime, signal, public-safe, production, and disposition claims remain blocked.
 
   - detection_id: HO-DET-011
     package_path: detections/successor/ho-det-011

--- a/detections/successor/ho-det-010/README.md
+++ b/detections/successor/ho-det-010/README.md
@@ -1,0 +1,31 @@
+# HO-DET-010 Windows Local Administrators Group Membership Change
+
+HO-DET-010 detects Windows local administrators group membership changes using
+controlled source artifacts only. It is intended for local lab validation and
+private runtime gating after separate approval.
+
+## Telemetry Model
+
+- Windows Security Event ID 4732: member added to local security-enabled group.
+- Windows Security Event ID 4733: member removed from local security-enabled group.
+- Optional Sysmon Event ID 1: process context for `net localgroup`, PowerShell
+  `Add-LocalGroupMember`, and `Remove-LocalGroupMember`.
+
+## Detection Intent
+
+The rule focuses on local Administrators membership changes, especially where
+the target group is `Administrators`, `Builtin\Administrators`, or the built-in
+administrators SID `S-1-5-32-544`.
+
+## Validation Boundary
+
+This package is source and controlled-test validation ready. It does not claim
+runtime activity, Wazuh routing, Splunk firing, public-safe status, production
+coverage, autonomous SOC authority, AI-approved disposition, analyst-approved
+disposition, or case closure.
+
+## Expected Follow-up
+
+Before any runtime attempt, require a separate governed VM108 gate with snapshot,
+one execution ID, immediate cleanup, sanitized evidence only, and no public proof
+promotion.

--- a/detections/successor/ho-det-010/event-mapping.yml
+++ b/detections/successor/ho-det-010/event-mapping.yml
@@ -1,0 +1,142 @@
+detection_id: HO-DET-010
+truth_surface: detection_source
+mapping_status: SOURCE_EXISTS
+validation_status: CONTROLLED_TEST_VALIDATED
+description: >
+  Event mapping for Windows local Administrators group membership changes. This
+  mapping supports controlled-test validation and does not prove runtime
+  activity, signal observation, routing, public-safe status, or evidence-linked
+  public proof.
+telemetry_boundary:
+  windows_security_4732: Windows Security Event ID 4732 may record a member added to a local security-enabled group.
+  windows_security_4733: Windows Security Event ID 4733 may record a member removed from a local security-enabled group.
+  sysmon_1: Sysmon Event ID 1 can provide process context for local group modification tooling where available.
+sources:
+  windows_security_4732:
+    channel: Security
+    event_id: 4732
+    role: local_group_member_added_event_where_available
+    expected_fields:
+      target_group:
+        common_names:
+          - TargetUserName
+          - GroupName
+      target_sid:
+        common_names:
+          - TargetSid
+      member_user:
+        common_names:
+          - MemberName
+          - MemberSid
+      subject_user:
+        common_names:
+          - SubjectUserName
+      host:
+        common_names:
+          - Computer
+  windows_security_4733:
+    channel: Security
+    event_id: 4733
+    role: local_group_member_removed_event_where_available
+    expected_fields:
+      target_group:
+        common_names:
+          - TargetUserName
+          - GroupName
+      target_sid:
+        common_names:
+          - TargetSid
+      member_user:
+        common_names:
+          - MemberName
+          - MemberSid
+      subject_user:
+        common_names:
+          - SubjectUserName
+  sysmon_event_1:
+    channel: Microsoft-Windows-Sysmon/Operational
+    provider: Sysmon
+    event_id: 1
+    role: process_context_for_local_group_modification_tooling
+    expected_fields:
+      process_image:
+        common_names:
+          - Image
+      command_line:
+        common_names:
+          - CommandLine
+      parent_image:
+        common_names:
+          - ParentImage
+wazuh_fields:
+  event_id:
+    candidates:
+      - win.system.eventID
+  target_group:
+    candidates:
+      - win.eventdata.targetUserName
+      - win.eventdata.TargetUserName
+      - win.eventdata.groupName
+  target_sid:
+    candidates:
+      - win.eventdata.targetSid
+      - win.eventdata.TargetSid
+  member_user:
+    candidates:
+      - win.eventdata.memberName
+      - win.eventdata.MemberName
+      - win.eventdata.memberSid
+  subject_user:
+    candidates:
+      - win.eventdata.subjectUserName
+      - win.eventdata.SubjectUserName
+  process_image:
+    candidates:
+      - win.eventdata.image
+  command_line:
+    candidates:
+      - win.eventdata.commandLine
+splunk_fields:
+  event_id:
+    candidates:
+      - EventCode
+      - EventID
+      - event_id
+  target_group:
+    candidates:
+      - TargetUserName
+      - GroupName
+      - group
+  target_sid:
+    candidates:
+      - TargetSid
+  member_user:
+    candidates:
+      - MemberName
+      - MemberSid
+      - user
+  subject_user:
+    candidates:
+      - SubjectUserName
+      - src_user
+  process_image:
+    candidates:
+      - Image
+      - process_path
+  command_line:
+    candidates:
+      - CommandLine
+      - ProcessCommandLine
+blocked_claims:
+  - runtime-active
+  - signal-observed
+  - public-safe
+  - evidence-linked public proof
+  - public-safe runtime proof
+  - live Splunk proof
+  - live Wazuh proof
+  - production-ready
+  - fleet-wide
+  - autonomous SOC
+  - AI-approved disposition
+  - analyst-approved disposition

--- a/detections/successor/ho-det-010/rule.yml
+++ b/detections/successor/ho-det-010/rule.yml
@@ -1,0 +1,119 @@
+title: HO-DET-010 Windows Local Administrators Group Membership Change
+detection_id: HO-DET-010
+name: Windows Local Administrators Group Membership Change
+status: experimental/source-validation-ready
+proof_level: SOURCE_EXISTS
+trust_class: SOURCE_EXISTS
+public_safe_status: NOT_PUBLIC_SAFE
+approval_status: NOT_APPROVED
+runtime_active: false
+validation_status: CONTROLLED_TEST_VALIDATED
+signal_observed: false
+evidence_linked_public_proof: false
+claim_ceiling: SOURCE_EXISTS
+description: >
+  Source detection for Windows local Administrators group membership changes.
+  This source uses Windows Security Event IDs 4732 and 4733 with optional
+  process context for local group membership tooling. It does not establish
+  runtime, signal, routing, public-safe proof, production coverage, or
+  privilege-management completeness.
+author: HawkinsOperations
+date: 2026-06-24
+references:
+  - https://attack.mitre.org/techniques/T1098/
+tags:
+  - attack.persistence
+  - attack.privilege-escalation
+  - attack.t1098
+mitre_attack:
+  tactic_ids:
+    - TA0003
+    - TA0004
+  tactic_names:
+    - Persistence
+    - Privilege Escalation
+  technique_ids:
+    - T1098
+  technique_names:
+    - Account Manipulation
+logsource:
+  product: windows
+  service: security
+data_source:
+  primary:
+    product: windows
+    channel: Security
+    event_ids:
+      - 4732
+      - 4733
+  related:
+    - product: windows
+      channel: Microsoft-Windows-Sysmon/Operational
+      event_ids:
+        - 1
+logic_summary: >
+  Flag local Administrators group membership add/remove activity and optional
+  process context where local group modification tooling is visible. Prioritize
+  membership additions and administrator group targets unless approved change
+  context exists.
+detection:
+  selection_security_local_group_membership:
+    EventID:
+      - 4732
+      - 4733
+  selection_administrators_group:
+    TargetSid|contains:
+      - S-1-5-32-544
+    TargetUserName|contains:
+      - Administrators
+      - BUILTIN\Administrators
+  selection_process_context:
+    EventID: 1
+    Image|endswith:
+      - '\net.exe'
+      - '\net1.exe'
+      - '\powershell.exe'
+      - '\pwsh.exe'
+      - '\cmd.exe'
+  selection_group_change_command:
+    CommandLine|contains:
+      - ' localgroup administrators '
+      - 'Add-LocalGroupMember'
+      - 'Remove-LocalGroupMember'
+      - 'Administrators'
+      - '/add'
+      - '/delete'
+  condition: selection_security_local_group_membership and selection_administrators_group or (selection_process_context and selection_group_change_command)
+falsepositives:
+  - Approved helpdesk local administrator provisioning.
+  - Break-glass account rotation under approved change control.
+  - Endpoint management remediation that temporarily adds and removes an admin.
+  - Documented lab reset or classroom administration workflow.
+tuning_guidance:
+  suspicious_context_review:
+    - Review member name, target group name/SID, creator identity, host role, and change window.
+    - Prioritize add events to local Administrators and unfamiliar local or domain principals.
+    - Correlate Security 4732/4733 with process context where Sysmon or process auditing is available.
+  benign_review_patterns:
+    - Approved helpdesk and endpoint management workflows.
+    - Break-glass rotation with ticket/change-control context.
+    - Lab reset activity under controlled maintenance context.
+level: high
+supported_claim: HO-DET-010 source artifacts exist and controlled-test validation is available in the validation repo.
+blocked_claims:
+  - runtime-active
+  - signal-observed
+  - public-safe
+  - evidence-linked public proof
+  - public-safe runtime proof
+  - live Splunk proof
+  - live Wazuh proof
+  - Cribl-routed proof
+  - Security Onion observed
+  - production-ready
+  - production triage
+  - fleet-wide
+  - autonomous SOC
+  - AI-approved disposition
+  - analyst-approved disposition
+  - privilege-management coverage completeness

--- a/detections/successor/ho-det-010/splunk.spl
+++ b/detections/successor/ho-det-010/splunk.spl
@@ -1,0 +1,10 @@
+index=windows (sourcetype=WinEventLog:Security (EventCode=4732 OR EventCode=4733))
+(
+  TargetSid="S-1-5-32-544"
+  OR like(TargetUserName, "%Administrators%")
+  OR like(GroupName, "%Administrators%")
+)
+| eval detection_id="HO-DET-010"
+| eval detection_name="Windows Local Administrators Group Membership Change"
+| eval proof_boundary="source_only_not_runtime_not_public_safe"
+| table _time host EventCode TargetUserName TargetSid MemberName MemberSid SubjectUserName detection_id detection_name proof_boundary

--- a/detections/successor/ho-det-010/status.yml
+++ b/detections/successor/ho-det-010/status.yml
@@ -1,0 +1,72 @@
+detection_id: HO-DET-010
+truth_surface: detection_source
+source_status: SOURCE_EXISTS
+sigma_source_status: SOURCE_EXISTS
+splunk_source_status: SOURCE_EXISTS
+wazuh_source_status: SOURCE_EXISTS
+event_mapping_status: SOURCE_EXISTS
+validation_status: CONTROLLED_TEST_VALIDATED
+validation_scope: controlled-test Windows local Administrators group membership fixtures only
+proof_level: SOURCE_EXISTS
+trust_class: SOURCE_EXISTS
+public_safe_status: NOT_PUBLIC_SAFE
+runtime_active: false
+signal_observed: false
+evidence_linked_public_proof: false
+proof_status: SOURCE_EXISTS
+runtime_active_status: NOT_PROVEN
+public_or_routed_signal_status: NOT_PROVEN
+wazuh_status: NOT_PROVEN
+splunk_status: NOT_PROVEN
+canonical_readme: detections/successor/ho-det-010/README.md
+canonical_sigma_source: detections/successor/ho-det-010/rule.yml
+canonical_splunk_source: detections/successor/ho-det-010/splunk.spl
+canonical_wazuh_source: detections/successor/ho-det-010/wazuh.xml
+canonical_event_mapping: detections/successor/ho-det-010/event-mapping.yml
+canonical_validation_cases: hawkinsoperations-validation/validation/successor/ho-det-010/validation-cases.json
+canonical_validation_result: hawkinsoperations-validation/reports/ho-det-010/validation-result.json
+telemetry_sources:
+  - Windows Security Event ID 4732 for member added to local security-enabled group.
+  - Windows Security Event ID 4733 for member removed from local security-enabled group.
+  - Sysmon Event ID 1 process context for local group modification tooling where available.
+tuning_focus:
+  suspicious_fields:
+    - TargetUserName or GroupName
+    - TargetSid
+    - MemberName or MemberSid
+    - SubjectUserName
+    - process command context where available
+  suspicious_indicators:
+    - additions to local Administrators
+    - built-in Administrators SID S-1-5-32-544
+    - unfamiliar local or domain principal added to local admin group
+  benign_review_patterns:
+    - approved helpdesk local administrator provisioning
+    - break-glass rotation under approved change control
+    - endpoint management remediation
+    - documented lab reset or classroom administration workflow
+allowed_claims:
+  - HO-DET-010 source artifacts exist.
+  - HO-DET-010 controlled-test validation is available in the validation repo.
+  - Detection source includes Sigma/SPL/Wazuh/event-mapping/status surfaces.
+blocked_claims:
+  - runtime-active
+  - signal-observed
+  - public-safe
+  - evidence-linked public proof
+  - live Splunk fired
+  - Splunk-fired
+  - Wazuh-routed
+  - Cribl-routed
+  - Security Onion observed
+  - production-ready
+  - fleet-wide
+  - autonomous SOC
+  - AI-approved disposition
+  - analyst-approved disposition
+  - privilege-management coverage completeness
+next_gate:
+  validation_repo_fixture_set: REQUIRED_BEFORE_RUNTIME
+  controlled_test_validation_harness: REQUIRED_BEFORE_RUNTIME
+  runtime_evidence: SEPARATE_VM108_GATE_REQUIRED
+  public_proof: BLOCKED_PENDING_PUBLIC_EVIDENCE_LINKAGE_REDACTION_REVIEW_AND_RAYLEE_APPROVAL

--- a/detections/successor/ho-det-010/wazuh.xml
+++ b/detections/successor/ho-det-010/wazuh.xml
@@ -1,0 +1,44 @@
+<!--
+  HO-DET-010 source-only Wazuh XML candidate.
+  This file is source truth only and does not claim live Wazuh routing,
+  runtime activity, signal observation, public-safe status, production SOC,
+  SOCaaS deployment, autonomous SOC, disposition approval, case closure, or
+  evidence-linked public proof.
+-->
+<group name="windows,privilege_change,local_admins,ho_det_010,source_only,">
+  <rule id="910101" level="8">
+    <if_group>windows</if_group>
+    <field name="win.system.eventID">4732|4733</field>
+    <field name="win.eventdata.targetSid" type="pcre2">(?i)S-1-5-32-544</field>
+    <description>HO-DET-010 candidate: Windows local Administrators group membership changed</description>
+    <mitre>
+      <id>T1098</id>
+    </mitre>
+    <options>no_full_log</options>
+    <group>ho-det-010,source-only,controlled-test-validated,</group>
+  </rule>
+
+  <rule id="910102" level="10">
+    <if_sid>910101</if_sid>
+    <field name="win.system.eventID">4732</field>
+    <description>HO-DET-010 candidate: member added to local Administrators group</description>
+    <mitre>
+      <id>T1098</id>
+    </mitre>
+    <options>no_full_log</options>
+    <group>ho-det-010,source-only,admin-add-context,blocked-claims-runtime-signal-public,</group>
+  </rule>
+
+  <rule id="910103" level="8">
+    <if_group>windows,sysmon</if_group>
+    <field name="win.system.eventID">1</field>
+    <field name="win.eventdata.image" type="pcre2">(?i)\\(net|net1|powershell|pwsh|cmd)\.exe$</field>
+    <field name="win.eventdata.commandLine" type="pcre2">(?i)(localgroup\s+administrators|add-localgroupmember|remove-localgroupmember|/add|/delete)</field>
+    <description>HO-DET-010 candidate: process context for local Administrators group modification tooling</description>
+    <mitre>
+      <id>T1098</id>
+    </mitre>
+    <options>no_full_log</options>
+    <group>ho-det-010,source-only,process-context,</group>
+  </rule>
+</group>

--- a/detections/wazuh/WAZUH_RULE_SOURCE_REGISTRY.yml
+++ b/detections/wazuh/WAZUH_RULE_SOURCE_REGISTRY.yml
@@ -60,6 +60,26 @@ entries:
     signal_status: false
     public_safe_status: NOT_PUBLIC_SAFE
     notes: Local user creation Wazuh XML exists as source-only rule source; validation fixtures remain controlled-test only and do not claim live Wazuh routing.
+  - detection_id: HO-DET-010
+    mapping_lane: wazuh_rule_source
+    status: SOURCE_EXISTS
+    detection_package: detections/successor/ho-det-010
+    wazuh_rule_path: detections/successor/ho-det-010/wazuh.xml
+    expected_rule_ids:
+      - 910101
+      - 910102
+      - 910103
+    expected_groups:
+      - ho-det-010
+      - source-only
+      - controlled-test-validated
+    expected_mitre_ids:
+      - T1098
+    preferred_runtime: wazuh_candidate_after_controlled_fixture
+    runtime_status: false
+    signal_status: false
+    public_safe_status: NOT_PUBLIC_SAFE
+    notes: Local Administrators group membership Wazuh XML exists as source-only rule source; validation fixtures remain controlled-test only and do not claim live Wazuh routing.
   - detection_id: HO-DET-012
     mapping_lane: wazuh_rule_source
     status: SOURCE_EXISTS


### PR DESCRIPTION
## Summary
- Adds HO-DET-010 source package for Windows local Administrators group membership changes.
- Adds Sigma-style source, Wazuh rule family 910101-910103, Splunk SPL, event mapping, and status boundary files.
- Updates the detection promotion matrix to source exists / controlled validation in validation repo / not public-safe.

## Validation
- `python -B scripts\verify_detection_contract.py` PASS
- `python -B scripts\verify_detection_promotion_matrix.py` PASS
- `python -B scripts\verify_wazuh_rule_sources.py` PASS
- `python -B -m unittest discover -s tests` PASS
- `git diff --check` PASS

## Boundary
- No private evidence committed.
- No raw alerts, raw command lines, endpoint logs, secrets, keys, tokens, binaries, VM credentials, or enrollment secrets committed.
- No public proof, Lifetime Ledger append, website update, schedule enablement, runtime rerun, production/customer/SOCaaS/fleet/autonomous/analyst-approved/case-closure claim, or merge.